### PR TITLE
Added test cases for REMP/OREMP

### DIFF
--- a/psi4/src/psi4/occ/manager.cc
+++ b/psi4/src/psi4/occ/manager.cc
@@ -761,7 +761,7 @@ void OCCWave::oremp_manager() {
         outfile->Printf("\n");
 
         // Set the global variables with the energies
-        variables_["OLCCD TOTAL ENERGY"] = EcepaL;
+        variables_["OREMP TOTAL ENERGY"] = EcepaL;
         variables_["CURRENT REFERENCE ENERGY"] = Escf;
 
         variables_["OREMP REFERENCE CORRECTION ENERGY"] = Eref - Escf;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfoccdat1 dfoccdat2 dfoccd-grad1 dfoccd-grad2
                   dfoccdt1 dfoccdt2 fnodfccsdt1 fnodfccsdt2 dfomp2-1 dfomp2-2 dfomp2-3
                   dfomp2-4 dfomp2-grad1 dfomp2-grad2 dfomp2-grad3 dfomp3-1 dfomp3-2
-                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1 dfremp-1 dfremp-2
+                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1 
+                  dforemp-engrad1 dforemp-engrad2 dfremp-1 dfremp-2
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   cc29 cc3 cc30 cc31 cc32 cc33 cc34 cc35 cc36 cc37 cc38 cc39
                   cc4 cc40 cc41 cc42 cc43 cc44 cc45 cc46 cc47 cc48 cc49 cc4a
                   cc50 cc51 cc52 cc53 cc54 cc55 cc5a cc6 cc7 cc8 cc8a cc8b cc8c
-                  cc9 cc9a cdomp2-1 cdomp2-2 cepa1
+                  cc9 cc9a cdomp2-1 cdomp2-2 cdremp-1 cdremp-2 cepa1
                   cepa2 cepa3 cepa-module ci-multi cisd-h2o+-0 cisd-h2o+-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2
@@ -52,7 +52,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfoccdat1 dfoccdat2 dfoccd-grad1 dfoccd-grad2
                   dfoccdt1 dfoccdt2 fnodfccsdt1 fnodfccsdt2 dfomp2-1 dfomp2-2 dfomp2-3
                   dfomp2-4 dfomp2-grad1 dfomp2-grad2 dfomp2-grad3 dfomp3-1 dfomp3-2
-                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1 dfremp-1
+                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1 dfremp-1 dfremp-2
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,7 +80,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9
                   opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-irc-3 opt-freeze-coords
                   opt-full-hess-every
-                  oremp-engrad1 
+                  oremp-engrad1 oremp-engrad2
                   phi-ao
                   props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,7 +79,9 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   omp3-3 omp3-4 omp3-5 omp3-grad1 omp3-grad2 opt-lindep-change
                   opt1 opt1-fd opt2 opt2-fd opt3 opt4 opt5 opt6 opt7 opt8 opt9
                   opt11 opt12 opt13 opt14 opt-irc-1 opt-irc-2 opt-irc-3 opt-freeze-coords
-                  opt-full-hess-every phi-ao
+                  opt-full-hess-every
+                  oremp-engrad1 
+                  phi-ao
                   props1 props2 props3 psimrcc-ccsd_t-1 psimrcc-ccsd_t-2
                   psimrcc-ccsd_t-3 psimrcc-ccsd_t-4 psimrcc-fd-freq1
                   psimrcc-fd-freq2 psimrcc-pt2 psimrcc-sp1 psithon1 psithon2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   dfmp2-grad2 dfmp2-grad3 dfmp2-grad4 dfmp2-grad5 dfoccdat1 dfoccdat2 dfoccd-grad1 dfoccd-grad2
                   dfoccdt1 dfoccdt2 fnodfccsdt1 fnodfccsdt2 dfomp2-1 dfomp2-2 dfomp2-3
                   dfomp2-4 dfomp2-grad1 dfomp2-grad2 dfomp2-grad3 dfomp3-1 dfomp3-2
-                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1
+                  dfomp3-grad1 dfomp3-grad2 dfomp2p5-1 dfomp2p5-2 dfomp2p5-grad1 dfremp-1
                   dft-grad-lr1 dft-grad-lr2 dft-grad-lr3 dft-grad-disk
                   dfomp2p5-grad2 dfrasscf-sp dfscf-bz2 dft-b2plyp dft-grac dft-ghost dft-grad-meta
                   dft-freq dft-freq-analytic dft-grad1 dft-grad2 dft-psivar dft-b3lyp dft1 dft-vv10

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   cc29 cc3 cc30 cc31 cc32 cc33 cc34 cc35 cc36 cc37 cc38 cc39
                   cc4 cc40 cc41 cc42 cc43 cc44 cc45 cc46 cc47 cc48 cc49 cc4a
                   cc50 cc51 cc52 cc53 cc54 cc55 cc5a cc6 cc7 cc8 cc8a cc8b cc8c
-                  cc9 cc9a cdomp2-1 cdomp2-2 cdremp-1 cdremp-2 cepa1
+                  cc9 cc9a cdomp2-1 cdomp2-2 cdoremp-energy1 cdoremp-energy2 cdremp-1 cdremp-2 cepa1
                   cepa2 cepa3 cepa-module ci-multi cisd-h2o+-0 cisd-h2o+-1
                   cisd-h2o+-2 cisd-h2o-clpse cisd-opt-fd cisd-sp cisd-sp-2
                   ci-property cubeprop cubeprop-frontier decontract dct-grad1 dct-grad2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,7 +89,7 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-db3
                   pywrap-molecule rasci-c2-active rasci-h2o
                   rasci-ne rasscf-sp 
-                  remp-energy1
+                  remp-energy1 remp-energy2
                   sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc sapt-ecp
                   sapt-exch-disp-inf
                   sapt7 sapt8 scf-bz2 scf-dipder scf-ecp scf-guess scf-guess-read1 scf-upcast-custom-basis

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,7 +88,9 @@ foreach(test_name adc1 adc2 casscf-fzc-sp casscf-semi casscf-sa-sp ao-casscf-sp 
                   pywrap-checkrun-rohf pywrap-checkrun-uhf pywrap-db1
                   pywrap-db3
                   pywrap-molecule rasci-c2-active rasci-h2o
-                  rasci-ne rasscf-sp sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc sapt-ecp
+                  rasci-ne rasscf-sp 
+                  remp-energy1
+                  sad-scf-type sad1 sapt1 sapt2 sapt3 sapt4 sapt5 sapt6 sapt-dft-api sapt-dft-lrc sapt-ecp
                   sapt-exch-disp-inf
                   sapt7 sapt8 scf-bz2 scf-dipder scf-ecp scf-guess scf-guess-read1 scf-upcast-custom-basis
                   scf-guess-read2 scf-guess-read3 scf-bs scf1 scf-occ scf2 scf3 scf4 scf5 scf6

--- a/tests/cdoremp-energy1/CMakeLists.txt
+++ b/tests/cdoremp-energy1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cdoremp-energy1 "psi;dfocc")

--- a/tests/cdoremp-energy1/input.dat
+++ b/tests/cdoremp-energy1/input.dat
@@ -1,0 +1,67 @@
+#! Cholesky decomposed OO-REMP/cc-pVDZ energy for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24306249760939,  #TEST
+                     "0.10": -76.24127222322905,  #TEST
+                     "0.20": -76.23968164560932,  #TEST
+                     "0.30": -76.23826103943726,  #TEST
+                     "1.00": -76.23161971459317}  #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  guess sad
+  scf_type cd
+  freeze_core false
+  wfn_type oremp
+  cc_type cd
+  mp_type cd
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+energy('oremp')
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+energy('oremp')
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.10) Total Energy") #TEST
+
+
+set remp_A=0.20
+energy('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+energy('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.30) Total Energy") #TEST
+
+
+set remp_A=1.00
+energy('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(1.00) Total Energy") #TEST

--- a/tests/cdoremp-energy1/output.ref
+++ b/tests/cdoremp-energy1/output.ref
@@ -1,0 +1,2143 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 06 December 2021 10:11AM
+
+    Process ID: 6095
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Cholesky decomposed OO-REMP/cc-pVDZ energy for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24306249760939,  #TEST
+                     "0.10": -76.24127222322905,  #TEST
+                     "0.20": -76.23968164560932,  #TEST
+                     "0.30": -76.23826103943726,  #TEST
+                     "1.00": -76.23161971459317}  #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  guess sad
+  scf_type cd
+  freeze_core false
+  wfn_type oremp
+  cc_type cd
+  mp_type cd
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+energy('oremp')
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+energy('oremp')
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.10) Total Energy") #TEST
+
+
+set remp_A=0.20
+energy('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+energy('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.30) Total Energy") #TEST
+
+
+set remp_A=1.00
+energy('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(1.00) Total Energy") #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:11:51 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51045149221868   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95395222460836   -4.43501e-01   1.74100e-02 DIIS
+   @RHF iter   2:   -76.00723767643601   -5.32855e-02   9.94871e-03 DIIS
+   @RHF iter   3:   -76.02631057740160   -1.90729e-02   9.07738e-04 DIIS
+   @RHF iter   4:   -76.02669585975460   -3.85282e-04   2.08301e-04 DIIS
+   @RHF iter   5:   -76.02671513457541   -1.92748e-05   3.82893e-05 DIIS
+   @RHF iter   6:   -76.02671605336194   -9.18787e-07   6.09459e-06 DIIS
+   @RHF iter   7:   -76.02671607921835   -2.58564e-08   8.53953e-07 DIIS
+   @RHF iter   8:   -76.02671607974179   -5.23443e-10   1.98049e-07 DIIS
+   @RHF iter   9:   -76.02671607977423   -3.24434e-11   3.36795e-08 DIIS
+   @RHF iter  10:   -76.02671607977510   -8.66862e-13   2.77332e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550545     2A     -1.336327     3A     -0.698818  
+       4A     -0.566526     5A     -0.493098  
+
+    Virtual:                                                              
+
+       6A      0.185476     7A      0.256186     8A      0.788758  
+       9A      0.853844    10A      1.163816    11A      1.200378  
+      12A      1.253470    13A      1.444403    14A      1.476194  
+      15A      1.674346    16A      1.867781    17A      1.934382  
+      18A      2.451140    19A      2.488687    20A      3.285197  
+      21A      3.338070    22A      3.509830    23A      3.865112  
+      24A      4.147187  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02671607977510
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375763360425424
+    Two-Electron Energy =                  37.9234737986776338
+    Total Energy =                        -76.0267160797750989
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Mon Dec  6 10:11:53 2021
+Module time:
+	user time   =       3.24 seconds =       0.05 minutes
+	system time =       1.09 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       3.24 seconds =       0.05 minutes
+	system time =       1.09 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:11:53 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.44 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977510
+	REF Energy (a.u.)                  :   -76.02671607977510
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20400801699175
+	CD-MP2 Total Energy (a.u.)         :   -76.23072409676685
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2424354453     -7.62e+01       7.08e-04         3.57e-03        9.74e-05 
+   2     -76.2429526605     -5.17e-04       2.45e-04         1.02e-03        5.53e-05 
+   3     -76.2430562584     -1.04e-04       3.85e-05         1.78e-04        1.23e-05 
+   4     -76.2430621005     -5.84e-06       9.74e-06         5.31e-05        5.42e-06 
+   5     -76.2430624833     -3.83e-07       1.39e-06         8.53e-06        6.84e-07 
+   6     -76.2430624970     -1.37e-08       2.55e-07         2.07e-06        1.67e-07 
+   7     -76.2430624976     -5.64e-10       6.05e-08         3.18e-07        4.34e-08 
+   8     -76.2430624976     -4.45e-11       2.24e-08         9.89e-08        9.87e-09 
+   9     -76.2430624976     -1.52e-12       3.93e-09         2.10e-08        2.20e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02671607977510
+	REF Energy (a.u.)                  :   -76.02600685040188
+	CD-REMP Correlation Energy (a.u.)  :    -0.21705564753820
+	CD-REMP Total Energy (a.u.)        :   -76.24306249760939
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977510
+	REF Energy (a.u.)                  :   -76.02600685040188
+	CD-OREMP Correlation Energy (a.u.) :    -0.21634641783429
+	Ecdoremp - Eref (a.u.)             :    -0.21705564720750
+	CD-OREMP Total Energy (a.u.)       :   -76.24306249760939
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:12:02 2021
+Module time:
+	user time   =      23.63 seconds =       0.39 minutes
+	system time =       9.24 seconds =       0.15 minutes
+	total time  =          9 seconds =       0.15 minutes
+Total time:
+	user time   =      26.88 seconds =       0.45 minutes
+	system time =      10.33 seconds =       0.17 minutes
+	total time  =         11 seconds =       0.18 minutes
+    CD-OREMP(0.00) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:02 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51045149221866   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95395222460840   -4.43501e-01   1.74100e-02 DIIS
+   @RHF iter   2:   -76.00723767643611   -5.32855e-02   9.94871e-03 DIIS
+   @RHF iter   3:   -76.02631057740163   -1.90729e-02   9.07738e-04 DIIS
+   @RHF iter   4:   -76.02669585975461   -3.85282e-04   2.08301e-04 DIIS
+   @RHF iter   5:   -76.02671513457555   -1.92748e-05   3.82893e-05 DIIS
+   @RHF iter   6:   -76.02671605336198   -9.18786e-07   6.09459e-06 DIIS
+   @RHF iter   7:   -76.02671607921859   -2.58566e-08   8.53953e-07 DIIS
+   @RHF iter   8:   -76.02671607974190   -5.23315e-10   1.98049e-07 DIIS
+   @RHF iter   9:   -76.02671607977430   -3.24007e-11   3.36795e-08 DIIS
+   @RHF iter  10:   -76.02671607977518   -8.81073e-13   2.77332e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550545     2A     -1.336327     3A     -0.698818  
+       4A     -0.566526     5A     -0.493098  
+
+    Virtual:                                                              
+
+       6A      0.185476     7A      0.256186     8A      0.788758  
+       9A      0.853844    10A      1.163816    11A      1.200378  
+      12A      1.253470    13A      1.444403    14A      1.476194  
+      15A      1.674346    16A      1.867781    17A      1.934382  
+      18A      2.451140    19A      2.488687    20A      3.285197  
+      21A      3.338070    22A      3.509830    23A      3.865112  
+      24A      4.147187  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02671607977518
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375763360425140
+    Two-Electron Energy =                  37.9234737986775130
+    Total Energy =                        -76.0267160797751842
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Mon Dec  6 10:12:03 2021
+Module time:
+	user time   =       1.26 seconds =       0.02 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      28.17 seconds =       0.47 minutes
+	system time =      10.80 seconds =       0.18 minutes
+	total time  =         12 seconds =       0.20 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:03 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.44 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977518
+	REF Energy (a.u.)                  :   -76.02671607977518
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20400801699175
+	CD-MP2 Total Energy (a.u.)         :   -76.23072409676693
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2408826722     -7.62e+01       6.40e-04         3.20e-03        2.07e-04 
+   2     -76.2412173663     -3.35e-04       2.00e-04         8.57e-04        8.17e-05 
+   3     -76.2412700821     -5.27e-05       2.54e-05         1.16e-04        9.57e-06 
+   4     -76.2412721149     -2.03e-06       6.00e-06         3.24e-05        2.05e-06 
+   5     -76.2412722203     -1.05e-07       7.41e-07         4.64e-06        5.89e-07 
+   6     -76.2412722231     -2.81e-09       1.21e-07         9.86e-07        7.82e-08 
+   7     -76.2412722232     -8.52e-11       2.37e-08         1.22e-07        1.70e-08 
+   8     -76.2412722232     -5.06e-12       8.10e-09         3.59e-08        2.63e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02671607977518
+	REF Energy (a.u.)                  :   -76.02601075091010
+	CD-REMP Correlation Energy (a.u.)  :    -0.21526148347310
+	CD-REMP Total Energy (a.u.)        :   -76.24127222322906
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977518
+	REF Energy (a.u.)                  :   -76.02601075091010
+	CD-OREMP Correlation Energy (a.u.) :    -0.21455614345388
+	Ecdoremp - Eref (a.u.)             :    -0.21526147231896
+	CD-OREMP Total Energy (a.u.)       :   -76.24127222322906
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:12:13 2021
+Module time:
+	user time   =      23.70 seconds =       0.40 minutes
+	system time =       9.80 seconds =       0.16 minutes
+	total time  =         10 seconds =       0.17 minutes
+Total time:
+	user time   =      51.87 seconds =       0.86 minutes
+	system time =      20.60 seconds =       0.34 minutes
+	total time  =         22 seconds =       0.37 minutes
+    CD-OREMP(0.10) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:13 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51045149221864   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95395222460840   -4.43501e-01   1.74100e-02 DIIS
+   @RHF iter   2:   -76.00723767643605   -5.32855e-02   9.94871e-03 DIIS
+   @RHF iter   3:   -76.02631057740165   -1.90729e-02   9.07738e-04 DIIS
+   @RHF iter   4:   -76.02669585975461   -3.85282e-04   2.08301e-04 DIIS
+   @RHF iter   5:   -76.02671513457560   -1.92748e-05   3.82893e-05 DIIS
+   @RHF iter   6:   -76.02671605336195   -9.18786e-07   6.09459e-06 DIIS
+   @RHF iter   7:   -76.02671607921862   -2.58567e-08   8.53953e-07 DIIS
+   @RHF iter   8:   -76.02671607974187   -5.23258e-10   1.98049e-07 DIIS
+   @RHF iter   9:   -76.02671607977435   -3.24718e-11   3.36795e-08 DIIS
+   @RHF iter  10:   -76.02671607977524   -8.95284e-13   2.77332e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550545     2A     -1.336327     3A     -0.698818  
+       4A     -0.566526     5A     -0.493098  
+
+    Virtual:                                                              
+
+       6A      0.185476     7A      0.256186     8A      0.788758  
+       9A      0.853844    10A      1.163816    11A      1.200378  
+      12A      1.253470    13A      1.444403    14A      1.476194  
+      15A      1.674346    16A      1.867781    17A      1.934382  
+      18A      2.451140    19A      2.488687    20A      3.285197  
+      21A      3.338070    22A      3.509830    23A      3.865112  
+      24A      4.147187  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02671607977524
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375763360425424
+    Two-Electron Energy =                  37.9234737986774988
+    Total Energy =                        -76.0267160797752410
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Mon Dec  6 10:12:14 2021
+Module time:
+	user time   =       2.70 seconds =       0.04 minutes
+	system time =       0.95 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      54.61 seconds =       0.91 minutes
+	system time =      21.56 seconds =       0.36 minutes
+	total time  =         23 seconds =       0.38 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:14 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.44 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02671607977524
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20400801699175
+	CD-MP2 Total Energy (a.u.)         :   -76.23072409676699
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2394488696     -7.62e+01       5.73e-04         2.85e-03        1.59e-04 
+   2     -76.2396559276     -2.07e-04       1.60e-04         7.04e-04        2.74e-05 
+   3     -76.2396809751     -2.50e-05       1.63e-05         7.13e-05        7.76e-06 
+   4     -76.2396816190     -6.44e-07       3.59e-06         1.91e-05        1.29e-06 
+   5     -76.2396816451     -2.61e-08       3.83e-07         2.44e-06        2.67e-07 
+   6     -76.2396816456     -5.11e-10       5.63e-08         4.52e-07        1.31e-08 
+   7     -76.2396816456     -1.14e-11       8.70e-09         4.24e-08        6.84e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02600706505237
+	CD-REMP Correlation Energy (a.u.)  :    -0.21367457190223
+	CD-REMP Total Energy (a.u.)        :   -76.23968164560934
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02600706505237
+	CD-OREMP Correlation Energy (a.u.) :    -0.21296556583410
+	Ecdoremp - Eref (a.u.)             :    -0.21367458055697
+	CD-OREMP Total Energy (a.u.)       :   -76.23968164560934
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:12:22 2021
+Module time:
+	user time   =      20.95 seconds =       0.35 minutes
+	system time =       8.72 seconds =       0.15 minutes
+	total time  =          8 seconds =       0.13 minutes
+Total time:
+	user time   =      75.56 seconds =       1.26 minutes
+	system time =      30.28 seconds =       0.50 minutes
+	total time  =         31 seconds =       0.52 minutes
+    CD-OREMP(0.20) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:22 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51045149221864   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95395222460837   -4.43501e-01   1.74100e-02 DIIS
+   @RHF iter   2:   -76.00723767643612   -5.32855e-02   9.94871e-03 DIIS
+   @RHF iter   3:   -76.02631057740159   -1.90729e-02   9.07738e-04 DIIS
+   @RHF iter   4:   -76.02669585975462   -3.85282e-04   2.08301e-04 DIIS
+   @RHF iter   5:   -76.02671513457562   -1.92748e-05   3.82893e-05 DIIS
+   @RHF iter   6:   -76.02671605336198   -9.18786e-07   6.09459e-06 DIIS
+   @RHF iter   7:   -76.02671607921857   -2.58566e-08   8.53953e-07 DIIS
+   @RHF iter   8:   -76.02671607974193   -5.23357e-10   1.98049e-07 DIIS
+   @RHF iter   9:   -76.02671607977435   -3.24150e-11   3.36795e-08 DIIS
+   @RHF iter  10:   -76.02671607977524   -8.95284e-13   2.77332e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550545     2A     -1.336327     3A     -0.698818  
+       4A     -0.566526     5A     -0.493098  
+
+    Virtual:                                                              
+
+       6A      0.185476     7A      0.256186     8A      0.788758  
+       9A      0.853844    10A      1.163816    11A      1.200378  
+      12A      1.253470    13A      1.444403    14A      1.476194  
+      15A      1.674346    16A      1.867781    17A      1.934382  
+      18A      2.451140    19A      2.488687    20A      3.285197  
+      21A      3.338070    22A      3.509830    23A      3.865112  
+      24A      4.147187  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02671607977524
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375763360425992
+    Two-Electron Energy =                  37.9234737986775485
+    Total Energy =                        -76.0267160797752410
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Mon Dec  6 10:12:23 2021
+Module time:
+	user time   =       2.76 seconds =       0.05 minutes
+	system time =       0.88 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      78.35 seconds =       1.31 minutes
+	system time =      31.18 seconds =       0.52 minutes
+	total time  =         32 seconds =       0.53 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:23 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.44 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02671607977524
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20400801699175
+	CD-MP2 Total Energy (a.u.)         :   -76.23072409676699
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2381286619     -7.62e+01       5.07e-04         2.50e-03        1.83e-04 
+   2     -76.2382499209     -1.21e-04       1.25e-04         5.65e-04        3.45e-05 
+   3     -76.2382608525     -1.09e-05       1.02e-05         4.10e-05        4.54e-06 
+   4     -76.2382610337     -1.81e-07       2.09e-06         1.08e-05        4.04e-07 
+   5     -76.2382610394     -5.64e-09       1.95e-07         1.23e-06        1.29e-07 
+   6     -76.2382610394     -8.05e-11       2.75e-08         1.99e-07        1.86e-08 
+   7     -76.2382610394     -1.31e-12       3.18e-09         1.30e-08        2.21e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02599705626548
+	CD-REMP Correlation Energy (a.u.)  :    -0.21226398086569
+	CD-REMP Total Energy (a.u.)        :   -76.23826103943728
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977524
+	REF Energy (a.u.)                  :   -76.02599705626548
+	CD-OREMP Correlation Energy (a.u.) :    -0.21154495966204
+	Ecdoremp - Eref (a.u.)             :    -0.21226398317179
+	CD-OREMP Total Energy (a.u.)       :   -76.23826103943728
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:12:32 2021
+Module time:
+	user time   =      22.41 seconds =       0.37 minutes
+	system time =       8.69 seconds =       0.14 minutes
+	total time  =          9 seconds =       0.15 minutes
+Total time:
+	user time   =     100.76 seconds =       1.68 minutes
+	system time =      39.87 seconds =       0.66 minutes
+	total time  =         41 seconds =       0.68 minutes
+    CD-OREMP(0.30) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:32 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51045149221864   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95395222460843   -4.43501e-01   1.74100e-02 DIIS
+   @RHF iter   2:   -76.00723767643603   -5.32855e-02   9.94871e-03 DIIS
+   @RHF iter   3:   -76.02631057740160   -1.90729e-02   9.07738e-04 DIIS
+   @RHF iter   4:   -76.02669585975462   -3.85282e-04   2.08301e-04 DIIS
+   @RHF iter   5:   -76.02671513457555   -1.92748e-05   3.82893e-05 DIIS
+   @RHF iter   6:   -76.02671605336197   -9.18786e-07   6.09459e-06 DIIS
+   @RHF iter   7:   -76.02671607921857   -2.58566e-08   8.53953e-07 DIIS
+   @RHF iter   8:   -76.02671607974186   -5.23286e-10   1.98049e-07 DIIS
+   @RHF iter   9:   -76.02671607977436   -3.25002e-11   3.36795e-08 DIIS
+   @RHF iter  10:   -76.02671607977520   -8.38440e-13   2.77332e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550545     2A     -1.336327     3A     -0.698818  
+       4A     -0.566526     5A     -0.493098  
+
+    Virtual:                                                              
+
+       6A      0.185476     7A      0.256186     8A      0.788758  
+       9A      0.853844    10A      1.163816    11A      1.200378  
+      12A      1.253470    13A      1.444403    14A      1.476194  
+      15A      1.674346    16A      1.867781    17A      1.934382  
+      18A      2.451140    19A      2.488687    20A      3.285197  
+      21A      3.338070    22A      3.509830    23A      3.865112  
+      24A      4.147187  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02671607977520
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375763360424713
+    Two-Electron Energy =                  37.9234737986774633
+    Total Energy =                        -76.0267160797751984
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Mon Dec  6 10:12:33 2021
+Module time:
+	user time   =       1.39 seconds =       0.02 minutes
+	system time =       0.52 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     102.18 seconds =       1.70 minutes
+	system time =      40.40 seconds =       0.67 minutes
+	total time  =         42 seconds =       0.70 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:12:33 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.44 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977520
+	REF Energy (a.u.)                  :   -76.02671607977520
+	CD-MP2 Correlation Energy (a.u.)   :    -0.20400801699175
+	CD-MP2 Total Energy (a.u.)         :   -76.23072409676695
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2316177546     -7.63e+01       2.18e-04         8.17e-04        2.41e-05 
+   2     -76.2316196989     -1.94e-06       1.74e-05         8.49e-05        1.44e-06 
+   3     -76.2316197145     -1.56e-08       1.34e-06         7.05e-06        1.30e-07 
+   4     -76.2316197146     -1.11e-10       1.22e-07         7.35e-07        1.35e-08 
+   5     -76.2316197146     -8.10e-13       1.36e-09         7.86e-09        1.25e-10 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02671607977520
+	REF Energy (a.u.)                  :   -76.02579750946894
+	CD-REMP Correlation Energy (a.u.)  :    -0.20582220512486
+	CD-REMP Total Energy (a.u.)        :   -76.23161971459309
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -76.02671607977520
+	REF Energy (a.u.)                  :   -76.02579750946894
+	CD-OREMP Correlation Energy (a.u.) :    -0.20490363481790
+	Ecdoremp - Eref (a.u.)             :    -0.20582220512415
+	CD-OREMP Total Energy (a.u.)       :   -76.23161971459309
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:12:41 2021
+Module time:
+	user time   =      18.87 seconds =       0.31 minutes
+	system time =       7.38 seconds =       0.12 minutes
+	total time  =          8 seconds =       0.13 minutes
+Total time:
+	user time   =     121.05 seconds =       2.02 minutes
+	system time =      47.78 seconds =       0.80 minutes
+	total time  =         50 seconds =       0.83 minutes
+    CD-OREMP(1.00) Total Energy...........................................................PASSED
+
+    Psi4 stopped on: Monday, 06 December 2021 10:12AM
+    Psi4 wall time for execution: 0:00:49.82
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cdoremp-energy2/CMakeLists.txt
+++ b/tests/cdoremp-energy2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cdoremp-energy2 "psi;dfocc")

--- a/tests/cdoremp-energy2/input.dat
+++ b/tests/cdoremp-energy2/input.dat
@@ -1,0 +1,68 @@
+#! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O+ molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80438002265420,  #TEST
+                     "0.10": -75.80183022936143,  #TEST
+                     "0.20": -75.79952095796595,  #TEST
+                     "0.30": -75.79739912861325,  #TEST
+                     "1.00": -75.78581160597487}  #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type cd
+  freeze_core false
+  wfn_type oremp
+  cc_type cd
+  mp_type cd
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+energy('oremp')
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+energy('oremp')
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.10) Total Energy") #TEST
+
+
+set remp_A=0.20
+energy('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+energy('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.30) Total Energy") #TEST
+
+
+set remp_A=1.00
+energy('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(1.00) Total Energy") #TEST

--- a/tests/cdoremp-energy2/output.ref
+++ b/tests/cdoremp-energy2/output.ref
@@ -1,0 +1,2389 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Monday, 06 December 2021 10:39AM
+
+    Process ID: 7376
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O+ molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80438002265420,  #TEST
+                     "0.10": -75.80183022936143,  #TEST
+                     "0.20": -75.79952095796595,  #TEST
+                     "0.30": -75.79739912861325,  #TEST
+                     "1.00": -75.78581160597487}  #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type cd
+  freeze_core false
+  wfn_type oremp
+  cc_type cd
+  mp_type cd
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+energy('oremp')
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+energy('oremp')
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.10) Total Energy") #TEST
+
+
+set remp_A=0.20
+energy('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+energy('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(0.30) Total Energy") #TEST
+
+
+set remp_A=1.00
+energy('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "CD-OREMP(1.00) Total Energy") #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:39:49 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51045149221865   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59294091119519   -8.24894e-02   1.13723e-02 DIIS
+   @UHF iter   2:   -75.62899600463568   -3.60551e-02   3.07765e-03 DIIS
+   @UHF iter   3:   -75.63138261492571   -2.38661e-03   1.08974e-03 DIIS
+   @UHF iter   4:   -75.63176696937280   -3.84354e-04   3.53779e-04 DIIS
+   @UHF iter   5:   -75.63184127568873   -7.43063e-05   1.56824e-04 DIIS
+   @UHF iter   6:   -75.63186187171387   -2.05960e-05   4.78727e-05 DIIS
+   @UHF iter   7:   -75.63186402043699   -2.14872e-06   8.09674e-06 DIIS
+   @UHF iter   8:   -75.63186407045221   -5.00152e-08   1.25081e-06 DIIS
+   @UHF iter   9:   -75.63186407131174   -8.59529e-10   2.49803e-07 DIIS
+   @UHF iter  10:   -75.63186407134978   -3.80425e-11   4.17773e-08 DIIS
+   @UHF iter  11:   -75.63186407135092   -1.13687e-12   7.40608e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087744505E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560877445E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140085     2A     -1.913832     3A     -1.218281  
+       4A     -1.130145     5A     -1.097776  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141716     7A     -0.058342     8A      0.392795  
+       9A      0.447107    10A      0.672504    11A      0.714959  
+      12A      0.827202    13A      1.024660    14A      1.039630  
+      15A      1.238681    16A      1.385470    17A      1.531651  
+      18A      1.995731    19A      2.004078    20A      2.722518  
+      21A      2.773414    22A      3.000697    23A      3.326392  
+      24A      3.652981  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095009     2A     -1.757764     3A     -1.180062  
+       4A     -1.045891  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313550     6A     -0.127647     7A     -0.050148  
+       8A      0.391618     9A      0.463581    10A      0.736307  
+      11A      0.844601    12A      0.870055    13A      1.035539  
+      14A      1.070122    15A      1.268976    16A      1.438092  
+      17A      1.528576    18A      2.007296    19A      2.059821  
+      20A      2.826422    21A      2.877992    22A      3.032475  
+      23A      3.405113    24A      3.670690  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63186407135092
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596551452739931
+    Two-Electron Energy =                  33.2404046163332723
+    Total Energy =                        -75.6318640713509183
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980709
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019291
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Mon Dec  6 10:39:50 2021
+Module time:
+	user time   =       1.83 seconds =       0.03 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.83 seconds =       0.03 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:39:50 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.89 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135092
+	REF Energy (a.u.)                  :   -75.63186407135092
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444365192810
+	Alpha-Beta Contribution (a.u.)     :    -0.11737831434379
+	Beta-Beta Contribution (a.u.)      :    -0.01140649217051
+	Scaled_SS Correlation Energy (a.u.):    -0.01195004803287
+	Scaled_OS Correlation Energy (a.u.):    -0.14085397721255
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78466809659633
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78445587999785
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69496032496447
+	CD-MP2 Correlation Energy (a.u.)   :    -0.15322845844240
+	CD-MP2 Total Energy (a.u.)         :   -75.78509252979332
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.8034997941     -7.58e+01       2.13e-03         1.11e-02        3.15e-04 
+   2     -75.8041338989     -6.34e-04       8.21e-04         3.31e-03        1.06e-04 
+   3     -75.8043141127     -1.80e-04       5.32e-04         1.98e-03        4.94e-05 
+   4     -75.8043571626     -4.30e-05       1.64e-04         6.52e-04        1.36e-05 
+   5     -75.8043754422     -1.83e-05       4.19e-05         1.91e-04        6.98e-06 
+   6     -75.8043797169     -4.27e-06       8.24e-06         4.50e-05        2.76e-06 
+   7     -75.8043799924     -2.76e-07       3.18e-06         1.57e-05        3.82e-07 
+   8     -75.8043800173     -2.49e-08       1.34e-06         7.36e-06        4.92e-07 
+   9     -75.8043800219     -4.58e-09       4.21e-07         3.35e-06        9.81e-08 
+  10     -75.8043800226     -6.69e-10       2.52e-07         1.07e-06        6.65e-08 
+  11     -75.8043800226     -7.74e-11       1.74e-07         7.10e-07        1.40e-08 
+  12     -75.8043800227     -8.38e-12       5.42e-08         2.34e-07        9.73e-09 
+  13     -75.8043800227     -1.49e-12       9.92e-09         7.18e-08        3.67e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63186407135092
+	REF Energy (a.u.)                  :   -75.63109363052308
+	Alpha-Alpha Contribution (a.u.)    :    -0.02384251636692
+	Alpha-Beta Contribution (a.u.)     :    -0.13866303200202
+	Beta-Beta Contribution (a.u.)      :    -0.01078085998516
+	CD-REMP Correlation Energy (a.u.)  :    -0.17328640835410
+	CD-REMP Total Energy (a.u.)        :   -75.80438002265416
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135092
+	REF Energy (a.u.)                  :   -75.63109363052308
+	CD-OREMP Correlation Energy (a.u.) :    -0.17251595130324
+	Ecdoremp - Eref (a.u.)             :    -0.17328639213108
+	CD-OREMP Total Energy (a.u.)       :   -75.80438002265416
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:40:25 2021
+Module time:
+	user time   =      88.54 seconds =       1.48 minutes
+	system time =      35.02 seconds =       0.58 minutes
+	total time  =         35 seconds =       0.58 minutes
+Total time:
+	user time   =      90.37 seconds =       1.51 minutes
+	system time =      35.62 seconds =       0.59 minutes
+	total time  =         36 seconds =       0.60 minutes
+    CD-OREMP(0.00) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:40:25 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51045149221868   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59294091119524   -8.24894e-02   1.13723e-02 DIIS
+   @UHF iter   2:   -75.62899600463578   -3.60551e-02   3.07765e-03 DIIS
+   @UHF iter   3:   -75.63138261492570   -2.38661e-03   1.08974e-03 DIIS
+   @UHF iter   4:   -75.63176696937293   -3.84354e-04   3.53779e-04 DIIS
+   @UHF iter   5:   -75.63184127568871   -7.43063e-05   1.56824e-04 DIIS
+   @UHF iter   6:   -75.63186187171392   -2.05960e-05   4.78727e-05 DIIS
+   @UHF iter   7:   -75.63186402043708   -2.14872e-06   8.09674e-06 DIIS
+   @UHF iter   8:   -75.63186407045229   -5.00152e-08   1.25081e-06 DIIS
+   @UHF iter   9:   -75.63186407131187   -8.59572e-10   2.49803e-07 DIIS
+   @UHF iter  10:   -75.63186407134985   -3.79856e-11   4.17773e-08 DIIS
+   @UHF iter  11:   -75.63186407135093   -1.08002e-12   7.40608e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087744505E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560877445E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140085     2A     -1.913832     3A     -1.218281  
+       4A     -1.130145     5A     -1.097776  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141716     7A     -0.058342     8A      0.392795  
+       9A      0.447107    10A      0.672504    11A      0.714959  
+      12A      0.827202    13A      1.024660    14A      1.039630  
+      15A      1.238681    16A      1.385470    17A      1.531651  
+      18A      1.995731    19A      2.004078    20A      2.722518  
+      21A      2.773414    22A      3.000697    23A      3.326392  
+      24A      3.652981  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095009     2A     -1.757764     3A     -1.180062  
+       4A     -1.045891  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313550     6A     -0.127647     7A     -0.050148  
+       8A      0.391618     9A      0.463581    10A      0.736307  
+      11A      0.844601    12A      0.870055    13A      1.035539  
+      14A      1.070122    15A      1.268976    16A      1.438092  
+      17A      1.528576    18A      2.007296    19A      2.059821  
+      20A      2.826422    21A      2.877992    22A      3.032475  
+      23A      3.405113    24A      3.670690  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63186407135093
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596551452738936
+    Two-Electron Energy =                  33.2404046163331515
+    Total Energy =                        -75.6318640713509325
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980709
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019291
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Mon Dec  6 10:40:26 2021
+Module time:
+	user time   =       1.52 seconds =       0.03 minutes
+	system time =       0.52 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      91.92 seconds =       1.53 minutes
+	system time =      36.16 seconds =       0.60 minutes
+	total time  =         37 seconds =       0.62 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:40:26 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.89 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135093
+	REF Energy (a.u.)                  :   -75.63186407135093
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444365192810
+	Alpha-Beta Contribution (a.u.)     :    -0.11737831434379
+	Beta-Beta Contribution (a.u.)      :    -0.01140649217051
+	Scaled_SS Correlation Energy (a.u.):    -0.01195004803287
+	Scaled_OS Correlation Energy (a.u.):    -0.14085397721255
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78466809659635
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78445587999786
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69496032496448
+	CD-MP2 Correlation Energy (a.u.)   :    -0.15322845844240
+	CD-MP2 Total Energy (a.u.)         :   -75.78509252979333
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.8012831729     -7.58e+01       2.10e-03         1.08e-02        2.13e-04 
+   2     -75.8017083416     -4.25e-04       7.84e-04         3.02e-03        8.62e-05 
+   3     -75.8018042247     -9.59e-05       5.05e-04         1.82e-03        3.31e-05 
+   4     -75.8018235471     -1.93e-05       1.40e-04         5.43e-04        1.85e-05 
+   5     -75.8018294035     -5.86e-06       3.52e-05         1.56e-04        6.64e-06 
+   6     -75.8018301964     -7.93e-07       6.18e-06         3.45e-05        1.44e-06 
+   7     -75.8018302266     -3.02e-08       1.39e-06         8.12e-06        4.36e-07 
+   8     -75.8018302290     -2.41e-09       5.24e-07         3.04e-06        1.61e-07 
+   9     -75.8018302293     -3.56e-10       1.33e-07         9.41e-07        5.08e-08 
+  10     -75.8018302294     -3.39e-11       5.96e-08         3.92e-07        1.08e-08 
+  11     -75.8018302294     -2.59e-12       3.44e-08         1.64e-07        2.85e-09 
+  12     -75.8018302294     -2.56e-13       6.57e-09         2.88e-08        9.91e-10 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63186407135093
+	REF Energy (a.u.)                  :   -75.63111969701623
+	Alpha-Alpha Contribution (a.u.)    :    -0.02401891793871
+	Alpha-Beta Contribution (a.u.)     :    -0.13576693791203
+	Beta-Beta Contribution (a.u.)      :    -0.01092467976487
+	CD-REMP Correlation Energy (a.u.)  :    -0.17071053561561
+	CD-REMP Total Energy (a.u.)        :   -75.80183022936143
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135093
+	REF Energy (a.u.)                  :   -75.63111969701623
+	CD-OREMP Correlation Energy (a.u.) :    -0.16996615801050
+	Ecdoremp - Eref (a.u.)             :    -0.17071053234520
+	CD-OREMP Total Energy (a.u.)       :   -75.80183022936143
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:40:59 2021
+Module time:
+	user time   =      81.62 seconds =       1.36 minutes
+	system time =      31.89 seconds =       0.53 minutes
+	total time  =         33 seconds =       0.55 minutes
+Total time:
+	user time   =     173.54 seconds =       2.89 minutes
+	system time =      68.05 seconds =       1.13 minutes
+	total time  =         70 seconds =       1.17 minutes
+    CD-OREMP(0.10) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:40:59 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51045149221864   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59294091119524   -8.24894e-02   1.13723e-02 DIIS
+   @UHF iter   2:   -75.62899600463575   -3.60551e-02   3.07765e-03 DIIS
+   @UHF iter   3:   -75.63138261492577   -2.38661e-03   1.08974e-03 DIIS
+   @UHF iter   4:   -75.63176696937292   -3.84354e-04   3.53779e-04 DIIS
+   @UHF iter   5:   -75.63184127568867   -7.43063e-05   1.56824e-04 DIIS
+   @UHF iter   6:   -75.63186187171389   -2.05960e-05   4.78727e-05 DIIS
+   @UHF iter   7:   -75.63186402043706   -2.14872e-06   8.09674e-06 DIIS
+   @UHF iter   8:   -75.63186407045229   -5.00152e-08   1.25081e-06 DIIS
+   @UHF iter   9:   -75.63186407131184   -8.59544e-10   2.49803e-07 DIIS
+   @UHF iter  10:   -75.63186407134987   -3.80282e-11   4.17773e-08 DIIS
+   @UHF iter  11:   -75.63186407135096   -1.09424e-12   7.40608e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087744505E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560877445E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140085     2A     -1.913832     3A     -1.218281  
+       4A     -1.130145     5A     -1.097776  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141716     7A     -0.058342     8A      0.392795  
+       9A      0.447107    10A      0.672504    11A      0.714959  
+      12A      0.827202    13A      1.024660    14A      1.039630  
+      15A      1.238681    16A      1.385470    17A      1.531651  
+      18A      1.995731    19A      2.004078    20A      2.722518  
+      21A      2.773414    22A      3.000697    23A      3.326392  
+      24A      3.652981  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095009     2A     -1.757764     3A     -1.180062  
+       4A     -1.045891  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313550     6A     -0.127647     7A     -0.050148  
+       8A      0.391618     9A      0.463581    10A      0.736307  
+      11A      0.844601    12A      0.870055    13A      1.035539  
+      14A      1.070122    15A      1.268976    16A      1.438092  
+      17A      1.528576    18A      2.007296    19A      2.059821  
+      20A      2.826422    21A      2.877992    22A      3.032475  
+      23A      3.405113    24A      3.670690  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63186407135096
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596551452739504
+    Two-Electron Energy =                  33.2404046163331799
+    Total Energy =                        -75.6318640713509609
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980709
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019291
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Mon Dec  6 10:41:00 2021
+Module time:
+	user time   =       2.36 seconds =       0.04 minutes
+	system time =       0.75 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     175.94 seconds =       2.93 minutes
+	system time =      68.80 seconds =       1.15 minutes
+	total time  =         71 seconds =       1.18 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:41:00 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.89 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63186407135096
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444365192810
+	Alpha-Beta Contribution (a.u.)     :    -0.11737831434379
+	Beta-Beta Contribution (a.u.)      :    -0.01140649217051
+	Scaled_SS Correlation Energy (a.u.):    -0.01195004803287
+	Scaled_OS Correlation Energy (a.u.):    -0.14085397721255
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78466809659638
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78445587999789
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69496032496451
+	CD-MP2 Correlation Energy (a.u.)   :    -0.15322845844240
+	CD-MP2 Total Energy (a.u.)         :   -75.78509252979336
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7991802771     -7.58e+01       2.07e-03         1.05e-02        2.54e-04 
+   2     -75.7994595011     -2.79e-04       7.55e-04         2.76e-03        7.96e-05 
+   3     -75.7995097443     -5.02e-05       4.80e-04         1.69e-03        1.40e-05 
+   4     -75.7995188618     -9.12e-06       1.24e-04         4.63e-04        5.47e-06 
+   5     -75.7995208053     -1.94e-06       3.09e-05         1.34e-04        2.46e-06 
+   6     -75.7995209544     -1.49e-07       5.44e-06         3.02e-05        5.16e-07 
+   7     -75.7995209577     -3.27e-09       1.07e-06         5.63e-06        1.23e-07 
+   8     -75.7995209579     -2.33e-10       2.69e-07         1.72e-06        3.57e-08 
+   9     -75.7995209580     -2.53e-11       6.15e-08         4.14e-07        1.33e-08 
+  10     -75.7995209580     -1.66e-12       1.79e-08         1.00e-07        3.33e-09 
+  11     -75.7995209580     -4.26e-14       8.94e-09         4.75e-08        6.44e-10 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63113696459658
+	Alpha-Alpha Contribution (a.u.)    :    -0.02416283087946
+	Alpha-Beta Contribution (a.u.)     :    -0.13317604111092
+	Beta-Beta Contribution (a.u.)      :    -0.01104512191088
+	CD-REMP Correlation Energy (a.u.)  :    -0.16838399390125
+	CD-REMP Total Energy (a.u.)        :   -75.79952095796598
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63113696459658
+	CD-OREMP Correlation Energy (a.u.) :    -0.16765688661502
+	Ecdoremp - Eref (a.u.)             :    -0.16838399336940
+	CD-OREMP Total Energy (a.u.)       :   -75.79952095796598
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:41:32 2021
+Module time:
+	user time   =      82.22 seconds =       1.37 minutes
+	system time =      32.26 seconds =       0.54 minutes
+	total time  =         32 seconds =       0.53 minutes
+Total time:
+	user time   =     258.16 seconds =       4.30 minutes
+	system time =     101.07 seconds =       1.68 minutes
+	total time  =        103 seconds =       1.72 minutes
+    CD-OREMP(0.20) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:41:32 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51045149221864   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59294091119523   -8.24894e-02   1.13723e-02 DIIS
+   @UHF iter   2:   -75.62899600463578   -3.60551e-02   3.07765e-03 DIIS
+   @UHF iter   3:   -75.63138261492574   -2.38661e-03   1.08974e-03 DIIS
+   @UHF iter   4:   -75.63176696937293   -3.84354e-04   3.53779e-04 DIIS
+   @UHF iter   5:   -75.63184127568870   -7.43063e-05   1.56824e-04 DIIS
+   @UHF iter   6:   -75.63186187171389   -2.05960e-05   4.78727e-05 DIIS
+   @UHF iter   7:   -75.63186402043705   -2.14872e-06   8.09674e-06 DIIS
+   @UHF iter   8:   -75.63186407045229   -5.00152e-08   1.25081e-06 DIIS
+   @UHF iter   9:   -75.63186407131184   -8.59544e-10   2.49803e-07 DIIS
+   @UHF iter  10:   -75.63186407134984   -3.79998e-11   4.17773e-08 DIIS
+   @UHF iter  11:   -75.63186407135098   -1.13687e-12   7.40608e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087744505E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560877445E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140085     2A     -1.913832     3A     -1.218281  
+       4A     -1.130145     5A     -1.097776  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141716     7A     -0.058342     8A      0.392795  
+       9A      0.447107    10A      0.672504    11A      0.714959  
+      12A      0.827202    13A      1.024660    14A      1.039630  
+      15A      1.238681    16A      1.385470    17A      1.531651  
+      18A      1.995731    19A      2.004078    20A      2.722518  
+      21A      2.773414    22A      3.000697    23A      3.326392  
+      24A      3.652981  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095009     2A     -1.757764     3A     -1.180062  
+       4A     -1.045891  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313550     6A     -0.127647     7A     -0.050148  
+       8A      0.391618     9A      0.463581    10A      0.736307  
+      11A      0.844601    12A      0.870055    13A      1.035539  
+      14A      1.070122    15A      1.268976    16A      1.438092  
+      17A      1.528576    18A      2.007296    19A      2.059821  
+      20A      2.826422    21A      2.877992    22A      3.032475  
+      23A      3.405113    24A      3.670690  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63186407135098
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596551452738936
+    Two-Electron Energy =                  33.2404046163331088
+    Total Energy =                        -75.6318640713509751
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980709
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019291
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Mon Dec  6 10:41:34 2021
+Module time:
+	user time   =       3.80 seconds =       0.06 minutes
+	system time =       1.25 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     262.00 seconds =       4.37 minutes
+	system time =     102.33 seconds =       1.71 minutes
+	total time  =        105 seconds =       1.75 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:41:34 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.89 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135098
+	REF Energy (a.u.)                  :   -75.63186407135098
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444365192810
+	Alpha-Beta Contribution (a.u.)     :    -0.11737831434379
+	Beta-Beta Contribution (a.u.)      :    -0.01140649217051
+	Scaled_SS Correlation Energy (a.u.):    -0.01195004803287
+	Scaled_OS Correlation Energy (a.u.):    -0.14085397721255
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78466809659639
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78445587999791
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69496032496453
+	CD-MP2 Correlation Energy (a.u.)   :    -0.15322845844240
+	CD-MP2 Total Energy (a.u.)         :   -75.78509252979337
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7971853596     -7.58e+01       2.04e-03         1.01e-02        1.87e-04 
+   2     -75.7973664889     -1.81e-04       7.32e-04         2.80e-03        6.16e-05 
+   3     -75.7973933698     -2.69e-05       4.56e-04         1.59e-03        1.66e-05 
+   4     -75.7973982685     -4.90e-06       1.12e-04         4.18e-04        3.28e-06 
+   5     -75.7973990804     -8.12e-07       2.71e-05         1.18e-04        8.44e-07 
+   6     -75.7973991270     -4.66e-08       4.59e-06         2.53e-05        1.90e-07 
+   7     -75.7973991285     -1.52e-09       7.86e-07         3.98e-06        1.07e-07 
+   8     -75.7973991286     -1.02e-10       1.52e-07         6.53e-07        4.06e-09 
+   9     -75.7973991286     -5.67e-12       2.92e-08         1.21e-07        3.11e-09 
+  10     -75.7973991286     -2.42e-13       9.51e-09         3.75e-08        1.19e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63186407135098
+	REF Energy (a.u.)                  :   -75.63114822795856
+	Alpha-Alpha Contribution (a.u.)    :    -0.02427974218800
+	Alpha-Beta Contribution (a.u.)     :    -0.13082493327758
+	Beta-Beta Contribution (a.u.)      :    -0.01114622712480
+	CD-REMP Correlation Energy (a.u.)  :    -0.16625090259039
+	CD-REMP Total Energy (a.u.)        :   -75.79739912861326
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135098
+	REF Energy (a.u.)                  :   -75.63114822795856
+	CD-OREMP Correlation Energy (a.u.) :    -0.16553505726229
+	Ecdoremp - Eref (a.u.)             :    -0.16625090065470
+	CD-OREMP Total Energy (a.u.)       :   -75.79739912861326
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:42:02 2021
+Module time:
+	user time   =      69.83 seconds =       1.16 minutes
+	system time =      27.39 seconds =       0.46 minutes
+	total time  =         28 seconds =       0.47 minutes
+Total time:
+	user time   =     331.83 seconds =       5.53 minutes
+	system time =     129.72 seconds =       2.16 minutes
+	total time  =        133 seconds =       2.22 minutes
+    CD-OREMP(0.30) Total Energy...........................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Mon Dec  6 10:42:02 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         121
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51045149221869   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59294091119526   -8.24894e-02   1.13723e-02 DIIS
+   @UHF iter   2:   -75.62899600463575   -3.60551e-02   3.07765e-03 DIIS
+   @UHF iter   3:   -75.63138261492574   -2.38661e-03   1.08974e-03 DIIS
+   @UHF iter   4:   -75.63176696937296   -3.84354e-04   3.53779e-04 DIIS
+   @UHF iter   5:   -75.63184127568871   -7.43063e-05   1.56824e-04 DIIS
+   @UHF iter   6:   -75.63186187171389   -2.05960e-05   4.78727e-05 DIIS
+   @UHF iter   7:   -75.63186402043705   -2.14872e-06   8.09674e-06 DIIS
+   @UHF iter   8:   -75.63186407045228   -5.00152e-08   1.25081e-06 DIIS
+   @UHF iter   9:   -75.63186407131184   -8.59558e-10   2.49803e-07 DIIS
+   @UHF iter  10:   -75.63186407134988   -3.80425e-11   4.17773e-08 DIIS
+   @UHF iter  11:   -75.63186407135096   -1.08002e-12   7.40608e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087744505E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560877445E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140085     2A     -1.913832     3A     -1.218281  
+       4A     -1.130145     5A     -1.097776  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141716     7A     -0.058342     8A      0.392795  
+       9A      0.447107    10A      0.672504    11A      0.714959  
+      12A      0.827202    13A      1.024660    14A      1.039630  
+      15A      1.238681    16A      1.385470    17A      1.531651  
+      18A      1.995731    19A      2.004078    20A      2.722518  
+      21A      2.773414    22A      3.000697    23A      3.326392  
+      24A      3.652981  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095009     2A     -1.757764     3A     -1.180062  
+       4A     -1.045891  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313550     6A     -0.127647     7A     -0.050148  
+       8A      0.391618     9A      0.463581    10A      0.736307  
+      11A      0.844601    12A      0.870055    13A      1.035539  
+      14A      1.070122    15A      1.268976    16A      1.438092  
+      17A      1.528576    18A      2.007296    19A      2.059821  
+      20A      2.826422    21A      2.877992    22A      3.032475  
+      23A      3.405113    24A      3.670690  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63186407135096
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596551452738794
+    Two-Electron Energy =                  33.2404046163331088
+    Total Energy =                        -75.6318640713509609
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980709
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019291
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Mon Dec  6 10:42:03 2021
+Module time:
+	user time   =       2.14 seconds =       0.04 minutes
+	system time =       0.63 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     334.01 seconds =       5.57 minutes
+	system time =     130.37 seconds =       2.17 minutes
+	total time  =        134 seconds =       2.23 minutes
+
+*** tstart() called on south
+*** at Mon Dec  6 10:42:03 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => CD              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     121
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.89 MB 
+	Memory requirement for DF-CC int trans:      1.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.72 MB 
+	Memory requirement for Wabef term     :      0.79 MB 
+
+	Computing CD-MP2 energy using SCF MOs (Canonical CD-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63186407135096
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444365192810
+	Alpha-Beta Contribution (a.u.)     :    -0.11737831434379
+	Beta-Beta Contribution (a.u.)      :    -0.01140649217051
+	Scaled_SS Correlation Energy (a.u.):    -0.01195004803287
+	Scaled_OS Correlation Energy (a.u.):    -0.14085397721255
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78466809659638
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78445587999789
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69496032496451
+	CD-MP2 Correlation Energy (a.u.)   :    -0.15322845844240
+	CD-MP2 Total Energy (a.u.)         :   -75.78509252979336
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing CD-OREMP iterations... ============================ 
+ ============================================================================== 
+	            Minimizing CD-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7857623297     -7.58e+01       1.86e-03         7.44e-03        1.79e-05 
+   2     -75.7858021561     -3.98e-05       6.91e-04         3.79e-03        4.02e-06 
+   3     -75.7858092088     -7.05e-06       3.51e-04         1.19e-03        2.05e-06 
+   4     -75.7858113704     -2.16e-06       7.41e-05         2.67e-04        4.70e-07 
+   5     -75.7858115996     -2.29e-07       1.07e-05         5.79e-05        1.64e-07 
+   6     -75.7858116059     -6.34e-09       1.19e-06         5.56e-06        1.61e-08 
+   7     -75.7858116060     -4.66e-11       2.52e-07         9.14e-07        3.23e-09 
+   8     -75.7858116060     -2.07e-12       5.73e-08         2.29e-07        6.22e-10 
+   9     -75.7858116060     -7.11e-14       1.08e-08         4.25e-08        1.47e-10 
+  10     -75.7858116060     -1.42e-14       1.47e-09         6.66e-09        1.05e-11 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing CD-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63114282213009
+	Alpha-Alpha Contribution (a.u.)    :    -0.02462824414886
+	Alpha-Beta Contribution (a.u.)     :    -0.11851904206397
+	Beta-Beta Contribution (a.u.)      :    -0.01152149763190
+	CD-REMP Correlation Energy (a.u.)  :    -0.15466878384474
+	CD-REMP Total Energy (a.u.)        :   -75.78581160597486
+	======================================================================= 
+
+	======================================================================= 
+	================ CD-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	CD-HF Energy (a.u.)                :   -75.63186407135096
+	REF Energy (a.u.)                  :   -75.63114282213009
+	CD-OREMP Correlation Energy (a.u.) :    -0.15394753462390
+	Ecdoremp - Eref (a.u.)             :    -0.15466878384477
+	CD-OREMP Total Energy (a.u.)       :   -75.78581160597486
+	======================================================================= 
+
+
+*** tstop() called on south at Mon Dec  6 10:42:32 2021
+Module time:
+	user time   =      72.93 seconds =       1.22 minutes
+	system time =      29.21 seconds =       0.49 minutes
+	total time  =         29 seconds =       0.48 minutes
+Total time:
+	user time   =     406.94 seconds =       6.78 minutes
+	system time =     159.58 seconds =       2.66 minutes
+	total time  =        163 seconds =       2.72 minutes
+    CD-OREMP(1.00) Total Energy...........................................................PASSED
+
+    Psi4 stopped on: Monday, 06 December 2021 10:42AM
+    Psi4 wall time for execution: 0:02:43.39
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cdremp-1/CMakeLists.txt
+++ b/tests/cdremp-1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cdremp-1 "psi;dfocc")

--- a/tests/cdremp-1/input.dat
+++ b/tests/cdremp-1/input.dat
@@ -1,0 +1,65 @@
+#! Cholesky decomposed REMP/cc-pVDZ energies for the CO2 molecule.
+
+test_dict = { "0.00": -188.31355173488825,  #TEST
+              "0.10": -188.31185799228328,  #TEST
+              "0.20": -188.31067714878031,  #TEST
+              "0.30": -188.30994506800923,  #TEST
+              "1.00": -188.31472976172114 } #TEST
+
+ESCF = -187.71397457500782
+
+molecule co2 {
+0 1
+C     0.1705487    0.3293777    0.0000000 
+O     1.2087051   -0.2081727    0.0000000 
+O    -0.8675996    0.8669312    0.0000000
+}
+
+
+
+set {
+  reference rhf
+  basis def2-TZVPP
+  freeze_core true
+  cc_type cd
+  mp2_type cd
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "CD-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(1.00) Total Energy") #TEST
+

--- a/tests/cdremp-1/output.ref
+++ b/tests/cdremp-1/output.ref
@@ -1,0 +1,2219 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 01 December 2021 07:48PM
+
+    Process ID: 27949
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Cholesky decomposed REMP/cc-pVDZ energies for the CO2 molecule.
+
+test_dict = { "0.00": -188.31355173488825,  #TEST
+              "0.10": -188.31185799228328,  #TEST
+              "0.20": -188.31067714878031,  #TEST
+              "0.30": -188.30994506800923,  #TEST
+              "1.00": -188.31472976172114 } #TEST
+
+ESCF = -187.71397457500782
+
+molecule co2 {
+0 1
+C     0.1705487    0.3293777    0.0000000 
+O     1.2087051   -0.2081727    0.0000000 
+O    -0.8675996    0.8669312    0.0000000
+}
+
+
+
+set {
+  reference rhf
+  basis def2-TZVPP
+  freeze_core true
+  cc_type cd
+  mp2_type cd
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "CD-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(1.00) Total Energy") #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:48:57 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         450
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -186.80596379083622   -1.86806e+02   0.00000e+00 
+   @RHF iter   1:  -187.62709602625253   -8.21132e-01   7.28828e-03 DIIS
+   @RHF iter   2:  -187.66745298611141   -4.03570e-02   5.43580e-03 DIIS
+   @RHF iter   3:  -187.71375751479729   -4.63045e-02   2.57405e-04 DIIS
+   @RHF iter   4:  -187.71396337617261   -2.05861e-04   5.64702e-05 DIIS
+   @RHF iter   5:  -187.71397393359069   -1.05574e-05   1.18742e-05 DIIS
+   @RHF iter   6:  -187.71397455723931   -6.23649e-07   1.82616e-06 DIIS
+   @RHF iter   7:  -187.71397457459571   -1.73564e-08   3.24867e-07 DIIS
+   @RHF iter   8:  -187.71397457499501   -3.99297e-10   7.00114e-08 DIIS
+   @RHF iter   9:  -187.71397457500723   -1.22213e-11   1.87251e-08 DIIS
+   @RHF iter  10:  -187.71397457500814   -9.09495e-13   7.79506e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651921     2Ap   -20.651879     3Ap   -11.463672  
+       4Ap    -1.525530     5Ap    -1.472490     6Ap    -0.800751  
+       7Ap    -0.741284     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543653     2App   -0.543653  
+
+    Virtual:                                                              
+
+      10Ap     0.133066    11Ap     0.192191     3App    0.192192  
+      12Ap     0.262031    13Ap     0.302684     4App    0.302685  
+      14Ap     0.480473    15Ap     0.493312    16Ap     0.550287  
+      17Ap     0.579886     5App    0.579887    18Ap     0.755403  
+       6App    0.755406    19Ap     0.756168     7App    0.756171  
+      20Ap     0.878022    21Ap     0.981076    22Ap     1.190469  
+       8App    1.190470    23Ap     1.241880    24Ap     1.492190  
+      25Ap     1.546883    26Ap     1.570589     9App    1.570590  
+      27Ap     1.638203    10App    1.638230    28Ap     1.920659  
+      11App    1.920691    29Ap     1.934358    12App    2.176671  
+      30Ap     2.176672    31Ap     2.291591    13App    2.291591  
+      32Ap     2.548540    33Ap     2.705327    14App    2.838204  
+      34Ap     2.838204    35Ap     3.092698    15App    3.092699  
+      16App    3.102211    36Ap     3.102211    17App    3.129009  
+      37Ap     3.129080    38Ap     3.209307    18App    3.209326  
+      39Ap     3.247430    40Ap     3.398391    41Ap     3.639726  
+      19App    3.699171    42Ap     3.699172    43Ap     3.975638  
+      20App    4.140089    44Ap     4.140089    45Ap     5.216047  
+      46Ap     5.279695    47Ap     5.500134    21App    5.500134  
+      48Ap     5.565620    22App    5.565620    49Ap     5.618981  
+      23App    5.618983    24App    6.220507    50Ap     6.220515  
+      51Ap     6.461145    52Ap     6.562981    25App    6.562981  
+      53Ap     6.777682    26App    6.777692    54Ap     6.778620  
+      27App    6.778631    28App    6.948299    55Ap     6.948299  
+      56Ap     7.191547    29App    7.191547    57Ap     7.351408  
+      30App    7.486928    58Ap     7.486928    59Ap     7.865925  
+      60Ap     7.979500    61Ap    24.925077    62Ap    45.402577  
+      63Ap    45.589585  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @RHF Final Energy:  -187.71397457500814
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6698748758303736
+    Two-Electron Energy =                 126.0169068520199858
+    Total Energy =                       -187.7139745750081374
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Wed Dec  1 19:49:02 2021
+Module time:
+	user time   =       7.40 seconds =       0.12 minutes
+	system time =       1.64 seconds =       0.03 minutes
+	total time  =          5 seconds =       0.08 minutes
+Total time:
+	user time   =       7.40 seconds =       0.12 minutes
+	system time =       1.64 seconds =       0.03 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:49:02 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     450
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     25.56 MB 
+	Memory requirement for DF-CC int trans:     78.96 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     38.69 MB 
+	Memory requirement for Wabef term     :     53.66 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	CD-HF Energy (a.u.)                :  -187.71397457500814
+	REF Energy (a.u.)                  :  -187.71397457500814
+	CD-MP2 Correlation Energy (a.u.)   :    -0.60075518671332
+	CD-MP2 Total Energy (a.u.)         :  -188.31472976172145
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5830287979          0.0177263889         4.61e-05  
+   2      -0.5958287273         -0.0127999295         1.93e-05  
+   3      -0.5994000628         -0.0035713355         9.01e-06  
+   4      -0.5994743456         -0.0000742828         2.32e-06  
+   5      -0.5995622887         -0.0000879432         4.05e-07  
+   6      -0.5995794603         -0.0000171715         2.11e-07  
+   7      -0.5995776030          0.0000018572         5.68e-08  
+   8      -0.5995780693         -0.0000004663         2.20e-08  
+   9      -0.5995774376          0.0000006317         2.00e-09  
+  10      -0.5995772766          0.0000001610         8.49e-10  
+  11      -0.5995772033          0.0000000733         2.73e-10  
+  12      -0.5995771713          0.0000000320         2.92e-10  
+  13      -0.5995771617          0.0000000096         4.95e-11  
+  14      -0.5995771598          0.0000000019         2.78e-11  
+  15      -0.5995771599         -0.0000000001         5.38e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71397457500814
+	REF Energy (a.u.)                  :  -187.71397457500814
+	CD-REMP Correlation Energy (a.u.)  :    -0.59957715988043
+	CD-REMP Total Energy (a.u.)        :  -188.31355173488856
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:49:24 2021
+Module time:
+	user time   =      63.79 seconds =       1.06 minutes
+	system time =      15.75 seconds =       0.26 minutes
+	total time  =         22 seconds =       0.37 minutes
+Total time:
+	user time   =      71.55 seconds =       1.19 minutes
+	system time =      17.57 seconds =       0.29 minutes
+	total time  =         27 seconds =       0.45 minutes
+    CD-SCF Energy.........................................................................PASSED
+    CD-REMP(0.00) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:49:24 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         450
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -186.80596379083639   -1.86806e+02   0.00000e+00 
+   @RHF iter   1:  -187.62709602625239   -8.21132e-01   7.28828e-03 DIIS
+   @RHF iter   2:  -187.66745298611156   -4.03570e-02   5.43580e-03 DIIS
+   @RHF iter   3:  -187.71375751479715   -4.63045e-02   2.57405e-04 DIIS
+   @RHF iter   4:  -187.71396337617284   -2.05861e-04   5.64702e-05 DIIS
+   @RHF iter   5:  -187.71397393359049   -1.05574e-05   1.18742e-05 DIIS
+   @RHF iter   6:  -187.71397455723940   -6.23649e-07   1.82616e-06 DIIS
+   @RHF iter   7:  -187.71397457459588   -1.73565e-08   3.24867e-07 DIIS
+   @RHF iter   8:  -187.71397457499535   -3.99467e-10   7.00114e-08 DIIS
+   @RHF iter   9:  -187.71397457500703   -1.16813e-11   1.87251e-08 DIIS
+   @RHF iter  10:  -187.71397457500780   -7.67386e-13   7.79506e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651921     2Ap   -20.651879     3Ap   -11.463672  
+       4Ap    -1.525530     5Ap    -1.472490     6Ap    -0.800751  
+       7Ap    -0.741284     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543653     2App   -0.543653  
+
+    Virtual:                                                              
+
+      10Ap     0.133066    11Ap     0.192191     3App    0.192192  
+      12Ap     0.262031    13Ap     0.302684     4App    0.302685  
+      14Ap     0.480473    15Ap     0.493312    16Ap     0.550287  
+      17Ap     0.579886     5App    0.579887    18Ap     0.755403  
+       6App    0.755406    19Ap     0.756168     7App    0.756171  
+      20Ap     0.878022    21Ap     0.981076    22Ap     1.190469  
+       8App    1.190470    23Ap     1.241880    24Ap     1.492190  
+      25Ap     1.546883    26Ap     1.570589     9App    1.570590  
+      27Ap     1.638203    10App    1.638230    28Ap     1.920659  
+      11App    1.920691    29Ap     1.934358    12App    2.176671  
+      30Ap     2.176672    31Ap     2.291591    13App    2.291591  
+      32Ap     2.548540    33Ap     2.705327    14App    2.838204  
+      34Ap     2.838204    35Ap     3.092698    15App    3.092699  
+      16App    3.102211    36Ap     3.102211    17App    3.129009  
+      37Ap     3.129080    38Ap     3.209307    18App    3.209326  
+      39Ap     3.247430    40Ap     3.398391    41Ap     3.639726  
+      19App    3.699171    42Ap     3.699172    43Ap     3.975638  
+      20App    4.140089    44Ap     4.140089    45Ap     5.216047  
+      46Ap     5.279695    47Ap     5.500134    21App    5.500134  
+      48Ap     5.565620    22App    5.565620    49Ap     5.618981  
+      23App    5.618983    24App    6.220507    50Ap     6.220515  
+      51Ap     6.461145    52Ap     6.562981    25App    6.562981  
+      53Ap     6.777682    26App    6.777692    54Ap     6.778620  
+      27App    6.778631    28App    6.948299    55Ap     6.948299  
+      56Ap     7.191547    29App    7.191547    57Ap     7.351408  
+      30App    7.486928    58Ap     7.486928    59Ap     7.865925  
+      60Ap     7.979500    61Ap    24.925077    62Ap    45.402577  
+      63Ap    45.589585  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @RHF Final Energy:  -187.71397457500780
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6698748758300326
+    Two-Electron Energy =                 126.0169068520200000
+    Total Energy =                       -187.7139745750077964
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Wed Dec  1 19:49:28 2021
+Module time:
+	user time   =       6.80 seconds =       0.11 minutes
+	system time =       1.51 seconds =       0.03 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      78.39 seconds =       1.31 minutes
+	system time =      19.09 seconds =       0.32 minutes
+	total time  =         31 seconds =       0.52 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:49:29 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     450
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     25.56 MB 
+	Memory requirement for DF-CC int trans:     78.96 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     38.69 MB 
+	Memory requirement for Wabef term     :     53.66 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	CD-HF Energy (a.u.)                :  -187.71397457500780
+	REF Energy (a.u.)                  :  -187.71397457500780
+	CD-MP2 Correlation Energy (a.u.)   :    -0.60075518671332
+	CD-MP2 Total Energy (a.u.)         :  -188.31472976172111
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5848014367          0.0159537500         4.88e-05  
+   2      -0.5954253185         -0.0106238818         1.83e-05  
+   3      -0.5978109438         -0.0023856253         5.73e-06  
+   4      -0.5978320294         -0.0000210856         1.09e-06  
+   5      -0.5978770451         -0.0000450157         3.34e-07  
+   6      -0.5978844379         -0.0000073928         8.85e-08  
+   7      -0.5978836479          0.0000007900         2.74e-08  
+   8      -0.5978836924         -0.0000000445         7.26e-09  
+   9      -0.5978834847          0.0000002077         2.08e-09  
+  10      -0.5978834419          0.0000000428         2.24e-10  
+  11      -0.5978834254          0.0000000165         1.65e-10  
+  12      -0.5978834190          0.0000000064         4.30e-11  
+  13      -0.5978834175          0.0000000015         1.74e-11  
+  14      -0.5978834173          0.0000000002         5.54e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71397457500780
+	REF Energy (a.u.)                  :  -187.71397457500780
+	CD-REMP Correlation Energy (a.u.)  :    -0.59788341727510
+	CD-REMP Total Energy (a.u.)        :  -188.31185799228288
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:49:49 2021
+Module time:
+	user time   =      60.52 seconds =       1.01 minutes
+	system time =      13.82 seconds =       0.23 minutes
+	total time  =         20 seconds =       0.33 minutes
+Total time:
+	user time   =     139.19 seconds =       2.32 minutes
+	system time =      33.11 seconds =       0.55 minutes
+	total time  =         52 seconds =       0.87 minutes
+    CD-REMP(0.10) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:49:49 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         450
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -186.80596379083616   -1.86806e+02   0.00000e+00 
+   @RHF iter   1:  -187.62709602625267   -8.21132e-01   7.28828e-03 DIIS
+   @RHF iter   2:  -187.66745298611147   -4.03570e-02   5.43580e-03 DIIS
+   @RHF iter   3:  -187.71375751479704   -4.63045e-02   2.57405e-04 DIIS
+   @RHF iter   4:  -187.71396337617281   -2.05861e-04   5.64702e-05 DIIS
+   @RHF iter   5:  -187.71397393359061   -1.05574e-05   1.18742e-05 DIIS
+   @RHF iter   6:  -187.71397455723948   -6.23649e-07   1.82616e-06 DIIS
+   @RHF iter   7:  -187.71397457459551   -1.73560e-08   3.24867e-07 DIIS
+   @RHF iter   8:  -187.71397457499512   -3.99609e-10   7.00114e-08 DIIS
+   @RHF iter   9:  -187.71397457500723   -1.21076e-11   1.87251e-08 DIIS
+   @RHF iter  10:  -187.71397457500797   -7.38964e-13   7.79506e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651921     2Ap   -20.651879     3Ap   -11.463672  
+       4Ap    -1.525530     5Ap    -1.472490     6Ap    -0.800751  
+       7Ap    -0.741284     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543653     2App   -0.543653  
+
+    Virtual:                                                              
+
+      10Ap     0.133066    11Ap     0.192191     3App    0.192192  
+      12Ap     0.262031    13Ap     0.302684     4App    0.302685  
+      14Ap     0.480473    15Ap     0.493312    16Ap     0.550287  
+      17Ap     0.579886     5App    0.579887    18Ap     0.755403  
+       6App    0.755406    19Ap     0.756168     7App    0.756171  
+      20Ap     0.878022    21Ap     0.981076    22Ap     1.190469  
+       8App    1.190470    23Ap     1.241880    24Ap     1.492190  
+      25Ap     1.546883    26Ap     1.570589     9App    1.570590  
+      27Ap     1.638203    10App    1.638230    28Ap     1.920659  
+      11App    1.920691    29Ap     1.934358    12App    2.176671  
+      30Ap     2.176672    31Ap     2.291591    13App    2.291591  
+      32Ap     2.548540    33Ap     2.705327    14App    2.838204  
+      34Ap     2.838204    35Ap     3.092698    15App    3.092699  
+      16App    3.102211    36Ap     3.102211    17App    3.129009  
+      37Ap     3.129080    38Ap     3.209307    18App    3.209326  
+      39Ap     3.247430    40Ap     3.398391    41Ap     3.639726  
+      19App    3.699171    42Ap     3.699172    43Ap     3.975638  
+      20App    4.140089    44Ap     4.140089    45Ap     5.216047  
+      46Ap     5.279695    47Ap     5.500134    21App    5.500134  
+      48Ap     5.565620    22App    5.565620    49Ap     5.618981  
+      23App    5.618983    24App    6.220507    50Ap     6.220515  
+      51Ap     6.461145    52Ap     6.562981    25App    6.562981  
+      53Ap     6.777682    26App    6.777692    54Ap     6.778620  
+      27App    6.778631    28App    6.948299    55Ap     6.948299  
+      56Ap     7.191547    29App    7.191547    57Ap     7.351408  
+      30App    7.486928    58Ap     7.486928    59Ap     7.865925  
+      60Ap     7.979500    61Ap    24.925077    62Ap    45.402577  
+      63Ap    45.589585  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @RHF Final Energy:  -187.71397457500797
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6698748758301463
+    Two-Electron Energy =                 126.0169068520199431
+    Total Energy =                       -187.7139745750079669
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Wed Dec  1 19:49:53 2021
+Module time:
+	user time   =       6.91 seconds =       0.12 minutes
+	system time =       1.57 seconds =       0.03 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =     146.14 seconds =       2.44 minutes
+	system time =      34.70 seconds =       0.58 minutes
+	total time  =         56 seconds =       0.93 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:49:53 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     450
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     25.56 MB 
+	Memory requirement for DF-CC int trans:     78.96 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     38.69 MB 
+	Memory requirement for Wabef term     :     53.66 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	CD-HF Energy (a.u.)                :  -187.71397457500797
+	REF Energy (a.u.)                  :  -187.71397457500797
+	CD-MP2 Correlation Energy (a.u.)   :    -0.60075518671332
+	CD-MP2 Total Energy (a.u.)         :  -188.31472976172128
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5865740756          0.0141811111         5.62e-05  
+   2      -0.5951582482         -0.0085841726         1.36e-05  
+   3      -0.5966767509         -0.0015185027         5.24e-06  
+   4      -0.5966776288         -0.0000008779         8.76e-07  
+   5      -0.5966999546         -0.0000223258         1.94e-07  
+   6      -0.5967029830         -0.0000030284         1.01e-08  
+   7      -0.5967026699          0.0000003131         9.82e-09  
+   8      -0.5967026494          0.0000000205         3.23e-09  
+   9      -0.5967025886          0.0000000607         9.51e-10  
+  10      -0.5967025784          0.0000000102         1.72e-10  
+  11      -0.5967025751          0.0000000033         3.61e-11  
+  12      -0.5967025740          0.0000000011         1.04e-11  
+  13      -0.5967025738          0.0000000002         3.56e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71397457500797
+	REF Energy (a.u.)                  :  -187.71397457500797
+	CD-REMP Correlation Energy (a.u.)  :    -0.59670257377238
+	CD-REMP Total Energy (a.u.)        :  -188.31067714878034
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:50:15 2021
+Module time:
+	user time   =      60.20 seconds =       1.00 minutes
+	system time =      15.98 seconds =       0.27 minutes
+	total time  =         22 seconds =       0.37 minutes
+Total time:
+	user time   =     206.70 seconds =       3.44 minutes
+	system time =      50.84 seconds =       0.85 minutes
+	total time  =         78 seconds =       1.30 minutes
+    CD-REMP(0.20) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:50:15 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         450
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -186.80596379083607   -1.86806e+02   0.00000e+00 
+   @RHF iter   1:  -187.62709602625264   -8.21132e-01   7.28828e-03 DIIS
+   @RHF iter   2:  -187.66745298611161   -4.03570e-02   5.43580e-03 DIIS
+   @RHF iter   3:  -187.71375751479718   -4.63045e-02   2.57405e-04 DIIS
+   @RHF iter   4:  -187.71396337617279   -2.05861e-04   5.64702e-05 DIIS
+   @RHF iter   5:  -187.71397393359061   -1.05574e-05   1.18742e-05 DIIS
+   @RHF iter   6:  -187.71397455723931   -6.23649e-07   1.82616e-06 DIIS
+   @RHF iter   7:  -187.71397457459562   -1.73563e-08   3.24867e-07 DIIS
+   @RHF iter   8:  -187.71397457499504   -3.99410e-10   7.00114e-08 DIIS
+   @RHF iter   9:  -187.71397457500717   -1.21361e-11   1.87251e-08 DIIS
+   @RHF iter  10:  -187.71397457500780   -6.25278e-13   7.79506e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651921     2Ap   -20.651879     3Ap   -11.463672  
+       4Ap    -1.525530     5Ap    -1.472490     6Ap    -0.800751  
+       7Ap    -0.741284     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543653     2App   -0.543653  
+
+    Virtual:                                                              
+
+      10Ap     0.133066    11Ap     0.192191     3App    0.192192  
+      12Ap     0.262031    13Ap     0.302684     4App    0.302685  
+      14Ap     0.480473    15Ap     0.493312    16Ap     0.550287  
+      17Ap     0.579886     5App    0.579887    18Ap     0.755403  
+       6App    0.755406    19Ap     0.756168     7App    0.756171  
+      20Ap     0.878022    21Ap     0.981076    22Ap     1.190469  
+       8App    1.190470    23Ap     1.241880    24Ap     1.492190  
+      25Ap     1.546883    26Ap     1.570589     9App    1.570590  
+      27Ap     1.638203    10App    1.638230    28Ap     1.920659  
+      11App    1.920691    29Ap     1.934358    12App    2.176671  
+      30Ap     2.176672    31Ap     2.291591    13App    2.291591  
+      32Ap     2.548540    33Ap     2.705327    14App    2.838204  
+      34Ap     2.838204    35Ap     3.092698    15App    3.092699  
+      16App    3.102211    36Ap     3.102211    17App    3.129009  
+      37Ap     3.129080    38Ap     3.209307    18App    3.209326  
+      39Ap     3.247430    40Ap     3.398391    41Ap     3.639726  
+      19App    3.699171    42Ap     3.699172    43Ap     3.975638  
+      20App    4.140089    44Ap     4.140089    45Ap     5.216047  
+      46Ap     5.279695    47Ap     5.500134    21App    5.500134  
+      48Ap     5.565620    22App    5.565620    49Ap     5.618981  
+      23App    5.618983    24App    6.220507    50Ap     6.220515  
+      51Ap     6.461145    52Ap     6.562981    25App    6.562981  
+      53Ap     6.777682    26App    6.777692    54Ap     6.778620  
+      27App    6.778631    28App    6.948299    55Ap     6.948299  
+      56Ap     7.191547    29App    7.191547    57Ap     7.351408  
+      30App    7.486928    58Ap     7.486928    59Ap     7.865925  
+      60Ap     7.979500    61Ap    24.925077    62Ap    45.402577  
+      63Ap    45.589585  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @RHF Final Energy:  -187.71397457500780
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6698748758298052
+    Two-Electron Energy =                 126.0169068520197726
+    Total Energy =                       -187.7139745750077964
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Wed Dec  1 19:50:19 2021
+Module time:
+	user time   =       7.45 seconds =       0.12 minutes
+	system time =       1.73 seconds =       0.03 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =     214.17 seconds =       3.57 minutes
+	system time =      52.60 seconds =       0.88 minutes
+	total time  =         82 seconds =       1.37 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:50:19 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     450
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     25.56 MB 
+	Memory requirement for DF-CC int trans:     78.96 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     38.69 MB 
+	Memory requirement for Wabef term     :     53.66 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	CD-HF Energy (a.u.)                :  -187.71397457500780
+	REF Energy (a.u.)                  :  -187.71397457500780
+	CD-MP2 Correlation Energy (a.u.)   :    -0.60075518671332
+	CD-MP2 Total Energy (a.u.)         :  -188.31472976172111
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5883467145          0.0124084722         3.69e-05  
+   2      -0.5950532428         -0.0067065283         1.04e-05  
+   3      -0.5959634297         -0.0009101868         2.58e-06  
+   4      -0.5959590089          0.0000044208         4.50e-07  
+   5      -0.5959694917         -0.0000104828         1.77e-08  
+   6      -0.5959706394         -0.0000011477         8.69e-09  
+   7      -0.5959705263          0.0000001131         2.13e-09  
+   8      -0.5959705111          0.0000000152         9.13e-10  
+   9      -0.5959704957          0.0000000154         1.79e-10  
+  10      -0.5959704936          0.0000000021         3.32e-11  
+  11      -0.5959704930          0.0000000006         6.96e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71397457500780
+	REF Energy (a.u.)                  :  -187.71397457500780
+	CD-REMP Correlation Energy (a.u.)  :    -0.59597049300134
+	CD-REMP Total Energy (a.u.)        :  -188.30994506800914
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:50:36 2021
+Module time:
+	user time   =      48.48 seconds =       0.81 minutes
+	system time =      10.75 seconds =       0.18 minutes
+	total time  =         17 seconds =       0.28 minutes
+Total time:
+	user time   =     262.92 seconds =       4.38 minutes
+	system time =      63.57 seconds =       1.06 minutes
+	total time  =         99 seconds =       1.65 minutes
+    CD-REMP(0.30) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:50:36 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         450
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:  -186.80596379083616   -1.86806e+02   0.00000e+00 
+   @RHF iter   1:  -187.62709602625242   -8.21132e-01   7.28828e-03 DIIS
+   @RHF iter   2:  -187.66745298611147   -4.03570e-02   5.43580e-03 DIIS
+   @RHF iter   3:  -187.71375751479727   -4.63045e-02   2.57405e-04 DIIS
+   @RHF iter   4:  -187.71396337617293   -2.05861e-04   5.64702e-05 DIIS
+   @RHF iter   5:  -187.71397393359067   -1.05574e-05   1.18742e-05 DIIS
+   @RHF iter   6:  -187.71397455723971   -6.23649e-07   1.82616e-06 DIIS
+   @RHF iter   7:  -187.71397457459565   -1.73559e-08   3.24867e-07 DIIS
+   @RHF iter   8:  -187.71397457499529   -3.99638e-10   7.00114e-08 DIIS
+   @RHF iter   9:  -187.71397457500728   -1.19940e-11   1.87251e-08 DIIS
+   @RHF iter  10:  -187.71397457500800   -7.10543e-13   7.79505e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651921     2Ap   -20.651879     3Ap   -11.463672  
+       4Ap    -1.525530     5Ap    -1.472490     6Ap    -0.800751  
+       7Ap    -0.741284     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543653     2App   -0.543653  
+
+    Virtual:                                                              
+
+      10Ap     0.133066    11Ap     0.192191     3App    0.192192  
+      12Ap     0.262031    13Ap     0.302684     4App    0.302685  
+      14Ap     0.480473    15Ap     0.493312    16Ap     0.550287  
+      17Ap     0.579886     5App    0.579887    18Ap     0.755403  
+       6App    0.755406    19Ap     0.756168     7App    0.756171  
+      20Ap     0.878022    21Ap     0.981076    22Ap     1.190469  
+       8App    1.190470    23Ap     1.241880    24Ap     1.492190  
+      25Ap     1.546883    26Ap     1.570589     9App    1.570590  
+      27Ap     1.638203    10App    1.638230    28Ap     1.920659  
+      11App    1.920691    29Ap     1.934358    12App    2.176671  
+      30Ap     2.176672    31Ap     2.291591    13App    2.291591  
+      32Ap     2.548540    33Ap     2.705327    14App    2.838204  
+      34Ap     2.838204    35Ap     3.092698    15App    3.092699  
+      16App    3.102211    36Ap     3.102211    17App    3.129009  
+      37Ap     3.129080    38Ap     3.209307    18App    3.209326  
+      39Ap     3.247430    40Ap     3.398391    41Ap     3.639726  
+      19App    3.699171    42Ap     3.699172    43Ap     3.975638  
+      20App    4.140089    44Ap     4.140089    45Ap     5.216047  
+      46Ap     5.279695    47Ap     5.500134    21App    5.500134  
+      48Ap     5.565620    22App    5.565620    49Ap     5.618981  
+      23App    5.618983    24App    6.220507    50Ap     6.220515  
+      51Ap     6.461145    52Ap     6.562981    25App    6.562981  
+      53Ap     6.777682    26App    6.777692    54Ap     6.778620  
+      27App    6.778631    28App    6.948299    55Ap     6.948299  
+      56Ap     7.191547    29App    7.191547    57Ap     7.351408  
+      30App    7.486928    58Ap     7.486928    59Ap     7.865925  
+      60Ap     7.979500    61Ap    24.925077    62Ap    45.402577  
+      63Ap    45.589585  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @RHF Final Energy:  -187.71397457500800
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6698748758299189
+    Two-Electron Energy =                 126.0169068520196731
+    Total Energy =                       -187.7139745750079953
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Wed Dec  1 19:50:39 2021
+Module time:
+	user time   =       5.02 seconds =       0.08 minutes
+	system time =       0.75 seconds =       0.01 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =     267.98 seconds =       4.47 minutes
+	system time =      64.33 seconds =       1.07 minutes
+	total time  =        102 seconds =       1.70 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:50:40 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     450
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     25.56 MB 
+	Memory requirement for DF-CC int trans:     78.96 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     38.69 MB 
+	Memory requirement for Wabef term     :     53.66 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	CD-HF Energy (a.u.)                :  -187.71397457500800
+	REF Energy (a.u.)                  :  -187.71397457500800
+	CD-MP2 Correlation Energy (a.u.)   :    -0.60075518671332
+	CD-MP2 Total Energy (a.u.)         :  -188.31472976172131
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.6007551867          0.0000000000         2.80e-20  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71397457500800
+	REF Energy (a.u.)                  :  -187.71397457500800
+	CD-REMP Correlation Energy (a.u.)  :    -0.60075518671332
+	CD-REMP Total Energy (a.u.)        :  -188.31472976172131
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:50:41 2021
+Module time:
+	user time   =       5.26 seconds =       0.09 minutes
+	system time =       1.45 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     273.55 seconds =       4.56 minutes
+	system time =      65.96 seconds =       1.10 minutes
+	total time  =        104 seconds =       1.73 minutes
+    CD-REMP(1.00) Total Energy............................................................PASSED
+
+    Psi4 stopped on: Wednesday, 01 December 2021 07:50PM
+    Psi4 wall time for execution: 0:01:44.32
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/cdremp-2/CMakeLists.txt
+++ b/tests/cdremp-2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(cdremp-2 "psi;dfocc")

--- a/tests/cdremp-2/input.dat
+++ b/tests/cdremp-2/input.dat
@@ -1,0 +1,75 @@
+#! Cholesky decomposed REMP/cc-pVDZ energies for the CH3 radical
+
+test_dict = { "0.00": -39.68422644447701,  #TEST
+              "0.10": -39.68084282038076,  #TEST
+              "0.20": -39.67776263674433,  #TEST
+              "0.30": -39.67492294865124,  #TEST
+              "1.00": -39.65933004580626 } #TEST
+
+
+
+
+
+
+
+
+ESCF = -39.5329751322223117
+
+
+molecule ch3 {
+units bohr
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000      
+H    1.02022495761968     -1.76708146174709      0.00000000000000      
+H    1.02022495761968      1.76708146174709      0.00000000000000      
+H   -2.04044991523936      0.00000000000000      0.00000000000000      
+}
+
+
+
+set {
+  reference uhf
+  basis def2-SVP
+  freeze_core true
+  cc_type cd
+  mp2_type cd
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "CD-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(1.00) Total Energy") #TEST
+

--- a/tests/cdremp-2/output.ref
+++ b/tests/cdremp-2/output.ref
@@ -1,0 +1,2353 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 02 December 2021 12:25PM
+
+    Process ID: 19222
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! Cholesky decomposed REMP/cc-pVDZ energies for the CH3 radical
+
+test_dict = { "0.00": -39.68422644447701,  #TEST
+              "0.10": -39.68084282038076,  #TEST
+              "0.20": -39.67776263674433,  #TEST
+              "0.30": -39.67492294865124,  #TEST
+              "1.00": -39.65933004580626 } #TEST
+
+
+
+
+
+
+
+
+ESCF = -39.5329751322223117
+
+
+molecule ch3 {
+units bohr
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000      
+H    1.02022495761968     -1.76708146174709      0.00000000000000      
+H    1.02022495761968      1.76708146174709      0.00000000000000      
+H   -2.04044991523936      0.00000000000000      0.00000000000000      
+}
+
+
+
+set {
+  reference uhf
+  basis def2-SVP
+  freeze_core true
+  cc_type cd
+  mp2_type cd
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "CD-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "CD-REMP(1.00) Total Energy") #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Thu Dec  2 12:25:24 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         142
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -38.88372582115876   -3.88837e+01   0.00000e+00 
+   @UHF iter   1:   -39.50944009903279   -6.25714e-01   1.07553e-02 DIIS
+   @UHF iter   2:   -39.53042434792732   -2.09842e-02   3.21180e-03 DIIS
+   @UHF iter   3:   -39.53247694321112   -2.05260e-03   1.08189e-03 DIIS
+   @UHF iter   4:   -39.53287326876522   -3.96326e-04   4.03580e-04 DIIS
+   @UHF iter   5:   -39.53296480959131   -9.15408e-05   1.25878e-04 DIIS
+   @UHF iter   6:   -39.53297494240287   -1.01328e-05   1.85540e-05 DIIS
+   @UHF iter   7:   -39.53297512599528   -1.83592e-07   3.82640e-06 DIIS
+   @UHF iter   8:   -39.53297513217961   -6.18433e-09   3.77510e-07 DIIS
+   @UHF iter   9:   -39.53297513222189   -4.22773e-11   3.75213e-08 DIIS
+   @UHF iter  10:   -39.53297513222229   -4.05009e-13   5.30117e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112046185E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611204619E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240556     2A1    -0.935256     3A1    -0.579651  
+       1B1    -0.579647     1B2    -0.386085  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196561     5A1     0.268687     2B1     0.268725  
+       6A1     0.620134     3B1     0.620137     7A1     0.644594  
+       2B2     0.672188     8A1     0.855861     9A1     0.937418  
+       4B1     0.937441     3B2     1.435889     1A2     1.435891  
+       5B1     1.749074    10A1     1.876337     6B1     1.876343  
+       4B2     2.008849    11A1     2.115034     5B2     2.525790  
+       2A2     2.525811     7B1     2.557442    12A1     2.557446  
+      13A1     3.199989    14A1     3.279804     8B1     3.279818  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215581     2A1    -0.844580     3A1    -0.564480  
+       1B1    -0.564479  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141509     4A1     0.212983     5A1     0.275817  
+       2B1     0.275853     6A1     0.624676     3B1     0.624679  
+       7A1     0.687448     2B2     0.819854     8A1     0.889526  
+       9A1     0.950821     4B1     0.950843     3B2     1.487076  
+       1A2     1.487077     5B1     1.744486    10A1     1.879018  
+       6B1     1.879024     4B2     2.021292    11A1     2.197645  
+      12A1     2.562074     7B1     2.562083     5B2     2.579959  
+       2A2     2.579979    13A1     3.214713    14A1     3.291925  
+       8B1     3.291929  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @UHF Final Energy:   -39.53297513222229
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4965177644913581
+    Two-Electron Energy =                  22.2931014907357508
+    Total Energy =                        -39.5329751322222904
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9990581
+  HONO-1 :    3 A1 1.9963165
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036835
+  LUNO+1 :    5 A1 0.0009419
+  LUNO+2 :    2 B1 0.0009418
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Thu Dec  2 12:25:26 2021
+Module time:
+	user time   =       5.09 seconds =       0.08 minutes
+	system time =       1.54 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       5.09 seconds =       0.08 minutes
+	system time =       1.54 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Thu Dec  2 12:25:26 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     142
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.49 MB 
+	Memory requirement for DF-CC int trans:      2.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      1.03 MB 
+	Memory requirement for Wabef term     :      1.42 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	CD-HF Energy (a.u.)                :   -39.53297513222229
+	REF Energy (a.u.)                  :   -39.53297513222229
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Scaled_SS Correlation Energy (a.u.):    -0.00797814514805
+	Scaled_OS Correlation Energy (a.u.):    -0.12290457376774
+	CD-SCS-MP2 Total Energy (a.u.)     :   -39.66385785113808
+	CD-SOS-MP2 Total Energy (a.u.)     :   -39.66612175380401
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -39.57509973860399
+	CD-MP2 Correlation Energy (a.u.)   :    -0.12635491358393
+	CD-MP2 Total Energy (a.u.)         :   -39.65933004580622
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1448174966         -0.0184625831         3.95e-04  
+   2      -0.1507751577         -0.0059576611         1.09e-04  
+   3      -0.1511980051         -0.0004228474         9.73e-05  
+   4      -0.1512337215         -0.0000357164         5.24e-05  
+   5      -0.1512476584         -0.0000139369         1.41e-05  
+   6      -0.1512522232         -0.0000045648         2.77e-06  
+   7      -0.1512512540          0.0000009692         7.26e-07  
+   8      -0.1512510340          0.0000002200         2.47e-07  
+   9      -0.1512511771         -0.0000001431         5.46e-08  
+  10      -0.1512512683         -0.0000000911         1.48e-08  
+  11      -0.1512512989         -0.0000000307         4.95e-09  
+  12      -0.1512513073         -0.0000000083         2.61e-09  
+  13      -0.1512513108         -0.0000000035         1.65e-09  
+  14      -0.1512513122         -0.0000000014         5.81e-10  
+  15      -0.1512513123         -0.0000000001         3.20e-11  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53297513222229
+	REF Energy (a.u.)                  :   -39.53297513222229
+	Alpha-Alpha Contribution (a.u.)    :    -0.01843945440041
+	Beta-Beta Contribution (a.u.)      :    -0.00598415493852
+	Alpha-Beta Contribution (a.u.)     :    -0.12682770291576
+	CD-REMP Correlation Energy (a.u.)  :    -0.15125131225470
+	CD-REMP Total Energy (a.u.)        :   -39.68422644447699
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 12:25:48 2021
+Module time:
+	user time   =      52.94 seconds =       0.88 minutes
+	system time =      20.97 seconds =       0.35 minutes
+	total time  =         22 seconds =       0.37 minutes
+Total time:
+	user time   =      58.34 seconds =       0.97 minutes
+	system time =      22.58 seconds =       0.38 minutes
+	total time  =         24 seconds =       0.40 minutes
+    CD-SCF Energy.........................................................................PASSED
+    CD-REMP(0.00) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Thu Dec  2 12:25:48 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         142
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -38.88372582115879   -3.88837e+01   0.00000e+00 
+   @UHF iter   1:   -39.50944009903279   -6.25714e-01   1.07553e-02 DIIS
+   @UHF iter   2:   -39.53042434792733   -2.09842e-02   3.21180e-03 DIIS
+   @UHF iter   3:   -39.53247694321110   -2.05260e-03   1.08189e-03 DIIS
+   @UHF iter   4:   -39.53287326876521   -3.96326e-04   4.03580e-04 DIIS
+   @UHF iter   5:   -39.53296480959129   -9.15408e-05   1.25878e-04 DIIS
+   @UHF iter   6:   -39.53297494240287   -1.01328e-05   1.85540e-05 DIIS
+   @UHF iter   7:   -39.53297512599528   -1.83592e-07   3.82640e-06 DIIS
+   @UHF iter   8:   -39.53297513217959   -6.18432e-09   3.77510e-07 DIIS
+   @UHF iter   9:   -39.53297513222186   -4.22702e-11   3.75213e-08 DIIS
+   @UHF iter  10:   -39.53297513222230   -4.33431e-13   5.30117e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112046185E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611204619E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240556     2A1    -0.935256     3A1    -0.579651  
+       1B1    -0.579647     1B2    -0.386085  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196561     5A1     0.268687     2B1     0.268725  
+       6A1     0.620134     3B1     0.620137     7A1     0.644594  
+       2B2     0.672188     8A1     0.855861     9A1     0.937418  
+       4B1     0.937441     3B2     1.435889     1A2     1.435891  
+       5B1     1.749074    10A1     1.876337     6B1     1.876343  
+       4B2     2.008849    11A1     2.115034     5B2     2.525790  
+       2A2     2.525811     7B1     2.557442    12A1     2.557446  
+      13A1     3.199989    14A1     3.279804     8B1     3.279818  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215581     2A1    -0.844580     3A1    -0.564480  
+       1B1    -0.564479  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141509     4A1     0.212983     5A1     0.275817  
+       2B1     0.275853     6A1     0.624676     3B1     0.624679  
+       7A1     0.687448     2B2     0.819854     8A1     0.889526  
+       9A1     0.950821     4B1     0.950843     3B2     1.487076  
+       1A2     1.487077     5B1     1.744486    10A1     1.879018  
+       6B1     1.879024     4B2     2.021292    11A1     2.197645  
+      12A1     2.562074     7B1     2.562083     5B2     2.579959  
+       2A2     2.579979    13A1     3.214713    14A1     3.291925  
+       8B1     3.291929  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @UHF Final Energy:   -39.53297513222230
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4965177644913581
+    Two-Electron Energy =                  22.2931014907357437
+    Total Energy =                        -39.5329751322222975
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9990581
+  HONO-1 :    3 A1 1.9963165
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036835
+  LUNO+1 :    5 A1 0.0009419
+  LUNO+2 :    2 B1 0.0009418
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Thu Dec  2 12:25:50 2021
+Module time:
+	user time   =       3.63 seconds =       0.06 minutes
+	system time =       1.38 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      62.00 seconds =       1.03 minutes
+	system time =      23.98 seconds =       0.40 minutes
+	total time  =         26 seconds =       0.43 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Thu Dec  2 12:25:50 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     142
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.49 MB 
+	Memory requirement for DF-CC int trans:      2.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      1.03 MB 
+	Memory requirement for Wabef term     :      1.42 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	CD-HF Energy (a.u.)                :   -39.53297513222230
+	REF Energy (a.u.)                  :   -39.53297513222230
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Scaled_SS Correlation Energy (a.u.):    -0.00797814514805
+	Scaled_OS Correlation Energy (a.u.):    -0.12290457376774
+	CD-SCS-MP2 Total Energy (a.u.)     :   -39.66385785113809
+	CD-SOS-MP2 Total Energy (a.u.)     :   -39.66612175380402
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -39.57509973860400
+	CD-MP2 Correlation Energy (a.u.)   :    -0.12635491358393
+	CD-MP2 Total Energy (a.u.)         :   -39.65933004580623
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1429712383         -0.0166163248         2.99e-04  
+   2      -0.1476324388         -0.0046612005         1.45e-04  
+   3      -0.1478569027         -0.0002244638         6.67e-05  
+   4      -0.1478618043         -0.0000049016         2.64e-05  
+   5      -0.1478665019         -0.0000046976         5.31e-06  
+   6      -0.1478680166         -0.0000015147         8.94e-07  
+   7      -0.1478676617          0.0000003549         2.28e-07  
+   8      -0.1478676155          0.0000000462         6.99e-08  
+   9      -0.1478676594         -0.0000000439         1.26e-08  
+  10      -0.1478676806         -0.0000000212         2.83e-09  
+  11      -0.1478676864         -0.0000000058         8.68e-10  
+  12      -0.1478676878         -0.0000000013         4.67e-10  
+  13      -0.1478676882         -0.0000000004         2.23e-10  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53297513222230
+	REF Energy (a.u.)                  :   -39.53297513222230
+	Alpha-Alpha Contribution (a.u.)    :    -0.01843523591917
+	Beta-Beta Contribution (a.u.)      :    -0.00605291699277
+	Alpha-Beta Contribution (a.u.)     :    -0.12337953524650
+	CD-REMP Correlation Energy (a.u.)  :    -0.14786768815844
+	CD-REMP Total Energy (a.u.)        :   -39.68084282038074
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 12:26:07 2021
+Module time:
+	user time   =      41.14 seconds =       0.69 minutes
+	system time =      16.28 seconds =       0.27 minutes
+	total time  =         17 seconds =       0.28 minutes
+Total time:
+	user time   =     103.44 seconds =       1.72 minutes
+	system time =      40.32 seconds =       0.67 minutes
+	total time  =         43 seconds =       0.72 minutes
+    CD-REMP(0.10) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:07 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000    -0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000    -0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         142
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -38.88372582115881   -3.88837e+01   0.00000e+00 
+   @UHF iter   1:   -39.50944009903279   -6.25714e-01   1.07553e-02 DIIS
+   @UHF iter   2:   -39.53042434792732   -2.09842e-02   3.21180e-03 DIIS
+   @UHF iter   3:   -39.53247694321112   -2.05260e-03   1.08189e-03 DIIS
+   @UHF iter   4:   -39.53287326876522   -3.96326e-04   4.03580e-04 DIIS
+   @UHF iter   5:   -39.53296480959132   -9.15408e-05   1.25878e-04 DIIS
+   @UHF iter   6:   -39.53297494240287   -1.01328e-05   1.85540e-05 DIIS
+   @UHF iter   7:   -39.53297512599526   -1.83592e-07   3.82640e-06 DIIS
+   @UHF iter   8:   -39.53297513217957   -6.18430e-09   3.77510e-07 DIIS
+   @UHF iter   9:   -39.53297513222186   -4.22986e-11   3.75213e-08 DIIS
+   @UHF iter  10:   -39.53297513222230   -4.40536e-13   5.30117e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112046185E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611204619E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240556     2A1    -0.935256     3A1    -0.579651  
+       1B1    -0.579647     1B2    -0.386085  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196561     5A1     0.268687     2B1     0.268725  
+       6A1     0.620134     3B1     0.620137     7A1     0.644594  
+       2B2     0.672188     8A1     0.855861     9A1     0.937418  
+       4B1     0.937441     3B2     1.435889     1A2     1.435891  
+       5B1     1.749074    10A1     1.876337     6B1     1.876343  
+       4B2     2.008849    11A1     2.115034     5B2     2.525790  
+       2A2     2.525811     7B1     2.557442    12A1     2.557446  
+      13A1     3.199989    14A1     3.279804     8B1     3.279818  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215581     2A1    -0.844580     3A1    -0.564480  
+       1B1    -0.564479  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141509     4A1     0.212983     5A1     0.275817  
+       2B1     0.275853     6A1     0.624676     3B1     0.624679  
+       7A1     0.687448     2B2     0.819854     8A1     0.889526  
+       9A1     0.950821     4B1     0.950843     3B2     1.487076  
+       1A2     1.487077     5B1     1.744486    10A1     1.879018  
+       6B1     1.879024     4B2     2.021292    11A1     2.197645  
+      12A1     2.562074     7B1     2.562083     5B2     2.579959  
+       2A2     2.579979    13A1     3.214713    14A1     3.291925  
+       8B1     3.291929  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @UHF Final Energy:   -39.53297513222230
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4965177644913581
+    Two-Electron Energy =                  22.2931014907357330
+    Total Energy =                        -39.5329751322223046
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9990581
+  HONO-1 :    3 A1 1.9963165
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036835
+  LUNO+1 :    5 A1 0.0009419
+  LUNO+2 :    2 B1 0.0009418
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Thu Dec  2 12:26:09 2021
+Module time:
+	user time   =       4.86 seconds =       0.08 minutes
+	system time =       1.71 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     108.35 seconds =       1.81 minutes
+	system time =      42.07 seconds =       0.70 minutes
+	total time  =         45 seconds =       0.75 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:09 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     142
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.49 MB 
+	Memory requirement for DF-CC int trans:      2.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      1.03 MB 
+	Memory requirement for Wabef term     :      1.42 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	CD-HF Energy (a.u.)                :   -39.53297513222230
+	REF Energy (a.u.)                  :   -39.53297513222230
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Scaled_SS Correlation Energy (a.u.):    -0.00797814514805
+	Scaled_OS Correlation Energy (a.u.):    -0.12290457376774
+	CD-SCS-MP2 Total Energy (a.u.)     :   -39.66385785113810
+	CD-SOS-MP2 Total Energy (a.u.)     :   -39.66612175380403
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -39.57509973860400
+	CD-MP2 Correlation Energy (a.u.)   :    -0.12635491358393
+	CD-MP2 Total Energy (a.u.)         :   -39.65933004580624
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1411249800         -0.0147700664         3.16e-04  
+   2      -0.1446796156         -0.0035546356         1.28e-04  
+   3      -0.1447882496         -0.0001086339         4.07e-05  
+   4      -0.1447853182          0.0000029314         1.26e-05  
+   5      -0.1447871025         -0.0000017844         2.03e-06  
+   6      -0.1447876137         -0.0000005112         3.14e-07  
+   7      -0.1447874947          0.0000001190         7.13e-08  
+   8      -0.1447874870          0.0000000076         1.74e-08  
+   9      -0.1447874991         -0.0000000120         2.83e-09  
+  10      -0.1447875035         -0.0000000045         5.37e-10  
+  11      -0.1447875045         -0.0000000010         1.64e-10  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53297513222230
+	REF Energy (a.u.)                  :   -39.53297513222230
+	Alpha-Alpha Contribution (a.u.)    :    -0.01840636635983
+	Beta-Beta Contribution (a.u.)      :    -0.00610414087021
+	Alpha-Beta Contribution (a.u.)     :    -0.12027699729198
+	CD-REMP Correlation Energy (a.u.)  :    -0.14478750452203
+	CD-REMP Total Energy (a.u.)        :   -39.67776263674433
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 12:26:24 2021
+Module time:
+	user time   =      37.64 seconds =       0.63 minutes
+	system time =      14.86 seconds =       0.25 minutes
+	total time  =         15 seconds =       0.25 minutes
+Total time:
+	user time   =     146.27 seconds =       2.44 minutes
+	system time =      56.99 seconds =       0.95 minutes
+	total time  =         60 seconds =       1.00 minutes
+    CD-REMP(0.20) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:24 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H           -0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         142
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -38.88372582115876   -3.88837e+01   0.00000e+00 
+   @UHF iter   1:   -39.50944009903280   -6.25714e-01   1.07553e-02 DIIS
+   @UHF iter   2:   -39.53042434792732   -2.09842e-02   3.21180e-03 DIIS
+   @UHF iter   3:   -39.53247694321110   -2.05260e-03   1.08189e-03 DIIS
+   @UHF iter   4:   -39.53287326876522   -3.96326e-04   4.03580e-04 DIIS
+   @UHF iter   5:   -39.53296480959130   -9.15408e-05   1.25878e-04 DIIS
+   @UHF iter   6:   -39.53297494240286   -1.01328e-05   1.85540e-05 DIIS
+   @UHF iter   7:   -39.53297512599529   -1.83592e-07   3.82640e-06 DIIS
+   @UHF iter   8:   -39.53297513217960   -6.18431e-09   3.77510e-07 DIIS
+   @UHF iter   9:   -39.53297513222186   -4.22631e-11   3.75213e-08 DIIS
+   @UHF iter  10:   -39.53297513222232   -4.54747e-13   5.30117e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112046185E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611204619E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240556     2A1    -0.935256     3A1    -0.579651  
+       1B1    -0.579647     1B2    -0.386085  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196561     5A1     0.268687     2B1     0.268725  
+       6A1     0.620134     3B1     0.620137     7A1     0.644594  
+       2B2     0.672188     8A1     0.855861     9A1     0.937418  
+       4B1     0.937441     3B2     1.435889     1A2     1.435891  
+       5B1     1.749074    10A1     1.876337     6B1     1.876343  
+       4B2     2.008849    11A1     2.115034     5B2     2.525790  
+       2A2     2.525811     7B1     2.557442    12A1     2.557446  
+      13A1     3.199989    14A1     3.279804     8B1     3.279818  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215581     2A1    -0.844580     3A1    -0.564480  
+       1B1    -0.564479  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141509     4A1     0.212983     5A1     0.275817  
+       2B1     0.275853     6A1     0.624676     3B1     0.624679  
+       7A1     0.687448     2B2     0.819854     8A1     0.889526  
+       9A1     0.950821     4B1     0.950843     3B2     1.487076  
+       1A2     1.487077     5B1     1.744486    10A1     1.879018  
+       6B1     1.879024     4B2     2.021292    11A1     2.197645  
+      12A1     2.562074     7B1     2.562083     5B2     2.579959  
+       2A2     2.579979    13A1     3.214713    14A1     3.291925  
+       8B1     3.291929  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @UHF Final Energy:   -39.53297513222232
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4965177644914007
+    Two-Electron Energy =                  22.2931014907357650
+    Total Energy =                        -39.5329751322223188
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9990581
+  HONO-1 :    3 A1 1.9963165
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036835
+  LUNO+1 :    5 A1 0.0009419
+  LUNO+2 :    2 B1 0.0009418
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Thu Dec  2 12:26:26 2021
+Module time:
+	user time   =       3.58 seconds =       0.06 minutes
+	system time =       1.59 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     149.88 seconds =       2.50 minutes
+	system time =      58.60 seconds =       0.98 minutes
+	total time  =         62 seconds =       1.03 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:26 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     142
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.49 MB 
+	Memory requirement for DF-CC int trans:      2.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      1.03 MB 
+	Memory requirement for Wabef term     :      1.42 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	CD-HF Energy (a.u.)                :   -39.53297513222232
+	REF Energy (a.u.)                  :   -39.53297513222232
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Scaled_SS Correlation Energy (a.u.):    -0.00797814514805
+	Scaled_OS Correlation Energy (a.u.):    -0.12290457376774
+	CD-SCS-MP2 Total Energy (a.u.)     :   -39.66385785113811
+	CD-SOS-MP2 Total Energy (a.u.)     :   -39.66612175380404
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -39.57509973860402
+	CD-MP2 Correlation Energy (a.u.)   :    -0.12635491358393
+	CD-MP2 Total Energy (a.u.)         :   -39.65933004580625
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1392787217         -0.0129238081         2.76e-04  
+   2      -0.1419043711         -0.0026256493         9.48e-05  
+   3      -0.1419503047         -0.0000459336         2.35e-05  
+   4      -0.1419469692          0.0000033355         5.75e-06  
+   5      -0.1419476880         -0.0000007188         7.08e-07  
+   6      -0.1419478532         -0.0000001653         4.57e-08  
+   7      -0.1419478171          0.0000000362         1.87e-08  
+   8      -0.1419478164          0.0000000006         4.07e-09  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53297513222232
+	REF Energy (a.u.)                  :   -39.53297513222232
+	Alpha-Alpha Contribution (a.u.)    :    -0.01835859321309
+	Beta-Beta Contribution (a.u.)      :    -0.00614148032593
+	Alpha-Beta Contribution (a.u.)     :    -0.11744774288988
+	CD-REMP Correlation Energy (a.u.)  :    -0.14194781642891
+	CD-REMP Total Energy (a.u.)        :   -39.67492294865123
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 12:26:36 2021
+Module time:
+	user time   =      24.70 seconds =       0.41 minutes
+	system time =       9.35 seconds =       0.16 minutes
+	total time  =         10 seconds =       0.17 minutes
+Total time:
+	user time   =     174.81 seconds =       2.91 minutes
+	system time =      68.00 seconds =       1.13 minutes
+	total time  =         72 seconds =       1.20 minutes
+    CD-REMP(0.30) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    SCF Algorithm Type (re)set to CD.
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:36 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is CD.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> CDJK: Cholesky-decomposed J/K Matrices <==
+
+    J tasked:                     Yes
+    K tasked:                     Yes
+    wK tasked:                     No
+    OpenMP threads:                 4
+    Integrals threads:              4
+    Memory [MiB]:                 375
+    Algorithm:                   Core
+    Integral Cache:              SAVE
+    Schwarz Cutoff:             1E-12
+    Cholesky tolerance:      1.00E-04
+    No. Cholesky vectors:         142
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -38.88372582115883   -3.88837e+01   0.00000e+00 
+   @UHF iter   1:   -39.50944009903278   -6.25714e-01   1.07553e-02 DIIS
+   @UHF iter   2:   -39.53042434792732   -2.09842e-02   3.21180e-03 DIIS
+   @UHF iter   3:   -39.53247694321111   -2.05260e-03   1.08189e-03 DIIS
+   @UHF iter   4:   -39.53287326876520   -3.96326e-04   4.03580e-04 DIIS
+   @UHF iter   5:   -39.53296480959131   -9.15408e-05   1.25878e-04 DIIS
+   @UHF iter   6:   -39.53297494240290   -1.01328e-05   1.85540e-05 DIIS
+   @UHF iter   7:   -39.53297512599528   -1.83592e-07   3.82640e-06 DIIS
+   @UHF iter   8:   -39.53297513217959   -6.18431e-09   3.77510e-07 DIIS
+   @UHF iter   9:   -39.53297513222186   -4.22702e-11   3.75213e-08 DIIS
+   @UHF iter  10:   -39.53297513222231   -4.54747e-13   5.30117e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112046185E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611204619E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240556     2A1    -0.935256     3A1    -0.579651  
+       1B1    -0.579647     1B2    -0.386085  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196561     5A1     0.268687     2B1     0.268725  
+       6A1     0.620134     3B1     0.620137     7A1     0.644594  
+       2B2     0.672188     8A1     0.855861     9A1     0.937418  
+       4B1     0.937441     3B2     1.435889     1A2     1.435891  
+       5B1     1.749074    10A1     1.876337     6B1     1.876343  
+       4B2     2.008849    11A1     2.115034     5B2     2.525790  
+       2A2     2.525811     7B1     2.557442    12A1     2.557446  
+      13A1     3.199989    14A1     3.279804     8B1     3.279818  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215581     2A1    -0.844580     3A1    -0.564480  
+       1B1    -0.564479  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141509     4A1     0.212983     5A1     0.275817  
+       2B1     0.275853     6A1     0.624676     3B1     0.624679  
+       7A1     0.687448     2B2     0.819854     8A1     0.889526  
+       9A1     0.950821     4B1     0.950843     3B2     1.487076  
+       1A2     1.487077     5B1     1.744486    10A1     1.879018  
+       6B1     1.879024     4B2     2.021292    11A1     2.197645  
+      12A1     2.562074     7B1     2.562083     5B2     2.579959  
+       2A2     2.579979    13A1     3.214713    14A1     3.291925  
+       8B1     3.291929  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @UHF Final Energy:   -39.53297513222231
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4965177644913865
+    Two-Electron Energy =                  22.2931014907357579
+    Total Energy =                        -39.5329751322223117
+
+  UHF NO Occupations:
+  HONO-2 :    2 A1 1.9990581
+  HONO-1 :    3 A1 1.9963165
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036835
+  LUNO+1 :    5 A1 0.0009419
+  LUNO+2 :    2 B1 0.0009418
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0001     Total:     0.0001
+
+
+*** tstop() called on south at Thu Dec  2 12:26:38 2021
+Module time:
+	user time   =       3.33 seconds =       0.06 minutes
+	system time =       1.13 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     178.17 seconds =       2.97 minutes
+	system time =      69.14 seconds =       1.15 minutes
+	total time  =         74 seconds =       1.23 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+
+*** tstart() called on south
+*** at Thu Dec  2 12:26:38 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CD              !
+  CHOLESKY                      => TRUE            !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => CD              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => CD              !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                    CD-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+	Reading Cholesky vectors from disk ...
+	Cholesky decomposition threshold: 1.00e-04
+	Number of Cholesky vectors:     142
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.49 MB 
+	Memory requirement for DF-CC int trans:      2.29 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      1.03 MB 
+	Memory requirement for Wabef term     :      1.42 MB 
+
+	Computing CD-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	CD-HF Energy (a.u.)                :   -39.53297513222231
+	REF Energy (a.u.)                  :   -39.53297513222231
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Scaled_SS Correlation Energy (a.u.):    -0.00797814514805
+	Scaled_OS Correlation Energy (a.u.):    -0.12290457376774
+	CD-SCS-MP2 Total Energy (a.u.)     :   -39.66385785113810
+	CD-SOS-MP2 Total Energy (a.u.)     :   -39.66612175380403
+	CD-SCSN-MP2 Total Energy (a.u.)    :   -39.57509973860401
+	CD-MP2 Correlation Energy (a.u.)   :    -0.12635491358393
+	CD-MP2 Total Energy (a.u.)         :   -39.65933004580624
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1263549136          0.0000000000         0.00e+00  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP2 FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53297513222231
+	REF Energy (a.u.)                  :   -39.53297513222231
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775221275803
+	Beta-Beta Contribution (a.u.)      :    -0.00618222268612
+	Alpha-Beta Contribution (a.u.)     :    -0.10242047813978
+	CD-REMP Correlation Energy (a.u.)  :    -0.12635491358393
+	CD-REMP Total Energy (a.u.)        :   -39.65933004580624
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 12:26:39 2021
+Module time:
+	user time   =       3.91 seconds =       0.07 minutes
+	system time =       1.62 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     182.37 seconds =       3.04 minutes
+	system time =      70.83 seconds =       1.18 minutes
+	total time  =         75 seconds =       1.25 minutes
+    CD-REMP(1.00) Total Energy............................................................PASSED
+
+    Psi4 stopped on: Thursday, 02 December 2021 12:26PM
+    Psi4 wall time for execution: 0:01:15.31
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dforemp-engrad1/CMakeLists.txt
+++ b/tests/dforemp-engrad1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dforemp-engrad1 "psi;dfocc")

--- a/tests/dforemp-engrad1/input.dat
+++ b/tests/dforemp-engrad1/input.dat
@@ -1,0 +1,104 @@
+#! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24301427323972,  #TEST
+                     "0.10": -76.24122429286781,  #TEST
+                     "0.20": -76.23963392905259,  #TEST
+                     "0.30": -76.23821346837765,  #TEST
+                     "1.00": -76.23157181769086}  #TEST
+
+   
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  guess sad
+  scf_type df
+  freeze_core false
+  wfn_type oremp
+  cc_type df
+  mp_type df
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [ 0.000000000000,    -0.000000000000,     0.013895310040 ],
+            [ 0.000000000000,     0.003248484259,    -0.006947655020 ],  
+            [ 0.000000000000,    -0.003248484259,    -0.006947655020 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.013197989518  ],
+            [  0.000000000000,     0.002783805920,    -0.006598994759  ],
+            [  0.000000000000,    -0.002783805920,    -0.006598994759  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.012728281086 ],
+            [  0.000000000000,     0.002453429980,    -0.006364140543 ],
+            [  0.000000000000,    -0.002453429980,    -0.006364140543 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.012438548445  ],
+            [  0.000000000000,     0.002229197714,    -0.006219274222  ],
+            [  0.000000000000,    -0.002229197714,    -0.006219274222  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,     0.000000000000,     0.013476662939  ],
+            [  0.000000000000,     0.002449235008,    -0.006738331469  ],
+            [  0.000000000000,    -0.002449235008,    -0.006738331469  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST

--- a/tests/dforemp-engrad1/output.ref
+++ b/tests/dforemp-engrad1/output.ref
@@ -1,0 +1,2555 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Thursday, 02 December 2021 05:50PM
+
+    Process ID: 26998
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24301427323972,  #TEST
+                     "0.10": -76.24122429286781,  #TEST
+                     "0.20": -76.23963392905259,  #TEST
+                     "0.30": -76.23821346837765,  #TEST
+                     "1.00": -76.23157181769086}  #TEST
+
+   
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  guess sad
+  scf_type df
+  freeze_core false
+  wfn_type oremp
+  cc_type df
+  mp_type df
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [ 0.000000000000,    -0.000000000000,     0.013895310040 ],
+            [ 0.000000000000,     0.003248484259,    -0.006947655020 ],  
+            [ 0.000000000000,    -0.003248484259,    -0.006947655020 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.013197989518  ],
+            [  0.000000000000,     0.002783805920,    -0.006598994759  ],
+            [  0.000000000000,    -0.002783805920,    -0.006598994759  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.012728281086 ],
+            [  0.000000000000,     0.002453429980,    -0.006364140543 ],
+            [  0.000000000000,    -0.002453429980,    -0.006364140543 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.012438548445  ],
+            [  0.000000000000,     0.002229197714,    -0.006219274222  ],
+            [  0.000000000000,    -0.002229197714,    -0.006219274222  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,     0.000000000000,     0.013476662939  ],
+            [  0.000000000000,     0.002449235008,    -0.006738331469  ],
+            [  0.000000000000,    -0.002449235008,    -0.006738331469  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:06 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51050601860275   -7.55105e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95396440048310   -4.43458e-01   1.74099e-02 DIIS
+   @DF-RHF iter   2:   -76.00724905192097   -5.32847e-02   9.94895e-03 DIIS
+   @DF-RHF iter   3:   -76.02632264302764   -1.90736e-02   9.08408e-04 DIIS
+   @DF-RHF iter   4:   -76.02670841043155   -3.85767e-04   2.08342e-04 DIIS
+   @DF-RHF iter   5:   -76.02672767732807   -1.92669e-05   3.82796e-05 DIIS
+   @DF-RHF iter   6:   -76.02672859528963   -9.17962e-07   6.10645e-06 DIIS
+   @DF-RHF iter   7:   -76.02672862124922   -2.59596e-08   8.54412e-07 DIIS
+   @DF-RHF iter   8:   -76.02672862177270   -5.23485e-10   1.98130e-07 DIIS
+   @DF-RHF iter   9:   -76.02672862180506   -3.23581e-11   3.37707e-08 DIIS
+   @DF-RHF iter  10:   -76.02672862180600   -9.37916e-13   2.77585e-09 DIIS
+   @DF-RHF iter  11:   -76.02672862180592    8.52651e-14   4.86617e-10 DIIS
+   @DF-RHF iter  12:   -76.02672862180601   -9.94760e-14   2.81762e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336338     3A     -0.698827  
+       4A     -0.566491     5A     -0.493092  
+
+    Virtual:                                                              
+
+       6A      0.185444     7A      0.256143     8A      0.788717  
+       9A      0.853857    10A      1.163774    11A      1.200480  
+      12A      1.253554    13A      1.444876    14A      1.476958  
+      15A      1.675152    16A      1.867645    17A      1.935173  
+      18A      2.451431    19A      2.489038    20A      3.286338  
+      21A      3.339125    22A      3.510967    23A      3.865989  
+      24A      4.148029  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -76.02672862180601
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375748709706244
+    Two-Electron Energy =                  37.9234597915747997
+    Total Energy =                        -76.0267286218060150
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1669
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8096     Total:     0.8096
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0579     Total:     2.0579
+
+
+*** tstop() called on south at Thu Dec  2 17:50:07 2021
+Module time:
+	user time   =       2.26 seconds =       0.04 minutes
+	system time =       0.67 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.26 seconds =       0.04 minutes
+	system time =       0.67 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:07 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.50 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02672862180601
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20394724679250
+	DF-MP2 Total Energy (a.u.)         :   -76.23067586859852
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2423874463     -7.62e+01       7.09e-04         3.57e-03        2.58e-04 
+   2     -76.2429044791     -5.17e-04       2.45e-04         1.02e-03        8.84e-05 
+   3     -76.2430080425     -1.04e-04       3.85e-05         1.78e-04        1.63e-05 
+   4     -76.2430138768     -5.83e-06       9.73e-06         5.31e-05        5.61e-06 
+   5     -76.2430142589     -3.82e-07       1.39e-06         8.53e-06        1.09e-06 
+   6     -76.2430142726     -1.37e-08       2.54e-07         2.06e-06        2.39e-07 
+   7     -76.2430142732     -5.60e-10       6.04e-08         3.17e-07        6.50e-08 
+   8     -76.2430142732     -4.41e-11       2.23e-08         9.84e-08        1.38e-08 
+   9     -76.2430142732     -1.55e-12       3.91e-09         2.09e-08        1.57e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02601897629903
+	DF-REMP Correlation Energy (a.u.)  :    -0.21699529715898
+	DF-REMP Total Energy (a.u.)        :   -76.23067586859852
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02601897629903
+	DF-OREMP Correlation Energy (a.u.) :    -0.21628565143368
+	Edforemp - Eref (a.u.)             :    -0.21699529694067
+	DF-OREMP Total Energy (a.u.)       :   -76.24301427323969
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 17:50:28 2021
+Module time:
+	user time   =      32.10 seconds =       0.54 minutes
+	system time =      13.16 seconds =       0.22 minutes
+	total time  =         21 seconds =       0.35 minutes
+Total time:
+	user time   =      34.58 seconds =       0.58 minutes
+	system time =      13.91 seconds =       0.23 minutes
+	total time  =         22 seconds =       0.37 minutes
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:28 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Thu Dec  2 17:50:28 2021
+Module time:
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      35.10 seconds =       0.58 minutes
+	system time =      14.22 seconds =       0.24 minutes
+	total time  =         22 seconds =       0.37 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.013895310040
+       2       -0.000000000000     0.003248484259    -0.006947655020
+       3        0.000000000000    -0.003248484259    -0.006947655020
+
+    OREMP(0.00) Total Energy..............................................................PASSED
+    OREMP(0.00) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:29 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51050601860275   -7.55105e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95396440048310   -4.43458e-01   1.74099e-02 DIIS
+   @DF-RHF iter   2:   -76.00724905192098   -5.32847e-02   9.94895e-03 DIIS
+   @DF-RHF iter   3:   -76.02632264302765   -1.90736e-02   9.08408e-04 DIIS
+   @DF-RHF iter   4:   -76.02670841043164   -3.85767e-04   2.08342e-04 DIIS
+   @DF-RHF iter   5:   -76.02672767732813   -1.92669e-05   3.82796e-05 DIIS
+   @DF-RHF iter   6:   -76.02672859528971   -9.17962e-07   6.10645e-06 DIIS
+   @DF-RHF iter   7:   -76.02672862124921   -2.59595e-08   8.54412e-07 DIIS
+   @DF-RHF iter   8:   -76.02672862177270   -5.23499e-10   1.98130e-07 DIIS
+   @DF-RHF iter   9:   -76.02672862180520   -3.25002e-11   3.37707e-08 DIIS
+   @DF-RHF iter  10:   -76.02672862180604   -8.38440e-13   2.77585e-09 DIIS
+   @DF-RHF iter  11:   -76.02672862180606   -1.42109e-14   4.86617e-10 DIIS
+   @DF-RHF iter  12:   -76.02672862180600    5.68434e-14   2.81762e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336338     3A     -0.698827  
+       4A     -0.566491     5A     -0.493092  
+
+    Virtual:                                                              
+
+       6A      0.185444     7A      0.256143     8A      0.788717  
+       9A      0.853857    10A      1.163774    11A      1.200480  
+      12A      1.253554    13A      1.444876    14A      1.476958  
+      15A      1.675152    16A      1.867645    17A      1.935173  
+      18A      2.451431    19A      2.489038    20A      3.286338  
+      21A      3.339125    22A      3.510967    23A      3.865989  
+      24A      4.148029  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -76.02672862180600
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375748709705391
+    Two-Electron Energy =                  37.9234597915747358
+    Total Energy =                        -76.0267286218060008
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1669
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8096     Total:     0.8096
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0579     Total:     2.0579
+
+
+*** tstop() called on south at Thu Dec  2 17:50:30 2021
+Module time:
+	user time   =       2.38 seconds =       0.04 minutes
+	system time =       0.63 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      37.74 seconds =       0.63 minutes
+	system time =      14.98 seconds =       0.25 minutes
+	total time  =         24 seconds =       0.40 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:30 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.50 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02672862180600
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20394724679250
+	DF-MP2 Total Energy (a.u.)         :   -76.23067586859851
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2408348773     -7.62e+01       6.40e-04         3.20e-03        2.33e-04 
+   2     -76.2411694570     -3.35e-04       2.00e-04         8.57e-04        8.66e-05 
+   3     -76.2412221547     -5.27e-05       2.54e-05         1.16e-04        1.38e-05 
+   4     -76.2412241847     -2.03e-06       5.99e-06         3.24e-05        3.29e-06 
+   5     -76.2412242900     -1.05e-07       7.40e-07         4.64e-06        5.89e-07 
+   6     -76.2412242928     -2.80e-09       1.20e-07         9.82e-07        1.08e-07 
+   7     -76.2412242929     -8.47e-11       2.37e-08         1.21e-07        2.56e-08 
+   8     -76.2412242929     -4.99e-12       8.05e-09         3.58e-08        4.73e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02602289425580
+	DF-REMP Correlation Energy (a.u.)  :    -0.21520140967736
+	DF-REMP Total Energy (a.u.)        :   -76.23067586859851
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02602289425580
+	DF-OREMP Correlation Energy (a.u.) :    -0.21449567106191
+	Edforemp - Eref (a.u.)             :    -0.21520139861211
+	DF-OREMP Total Energy (a.u.)       :   -76.24122429286791
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 17:50:50 2021
+Module time:
+	user time   =      28.55 seconds =       0.48 minutes
+	system time =      11.93 seconds =       0.20 minutes
+	total time  =         20 seconds =       0.33 minutes
+Total time:
+	user time   =      66.46 seconds =       1.11 minutes
+	system time =      26.94 seconds =       0.45 minutes
+	total time  =         44 seconds =       0.73 minutes
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:50 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Thu Dec  2 17:50:50 2021
+Module time:
+	user time   =       0.28 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      66.74 seconds =       1.11 minutes
+	system time =      27.09 seconds =       0.45 minutes
+	total time  =         44 seconds =       0.73 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.013197989518
+       2       -0.000000000000     0.002783805920    -0.006598994759
+       3        0.000000000000    -0.002783805920    -0.006598994759
+
+    OREMP(0.10) Total Energy..............................................................PASSED
+    OREMP(0.10) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:51 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51050601860277   -7.55105e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95396440048314   -4.43458e-01   1.74099e-02 DIIS
+   @DF-RHF iter   2:   -76.00724905192101   -5.32847e-02   9.94895e-03 DIIS
+   @DF-RHF iter   3:   -76.02632264302761   -1.90736e-02   9.08408e-04 DIIS
+   @DF-RHF iter   4:   -76.02670841043168   -3.85767e-04   2.08342e-04 DIIS
+   @DF-RHF iter   5:   -76.02672767732804   -1.92669e-05   3.82796e-05 DIIS
+   @DF-RHF iter   6:   -76.02672859528965   -9.17962e-07   6.10645e-06 DIIS
+   @DF-RHF iter   7:   -76.02672862124916   -2.59595e-08   8.54412e-07 DIIS
+   @DF-RHF iter   8:   -76.02672862177270   -5.23542e-10   1.98130e-07 DIIS
+   @DF-RHF iter   9:   -76.02672862180520   -3.25002e-11   3.37707e-08 DIIS
+   @DF-RHF iter  10:   -76.02672862180604   -8.38440e-13   2.77585e-09 DIIS
+   @DF-RHF iter  11:   -76.02672862180600    4.26326e-14   4.86617e-10 DIIS
+   @DF-RHF iter  12:   -76.02672862180600    0.00000e+00   2.81762e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336338     3A     -0.698827  
+       4A     -0.566491     5A     -0.493092  
+
+    Virtual:                                                              
+
+       6A      0.185444     7A      0.256143     8A      0.788717  
+       9A      0.853857    10A      1.163774    11A      1.200480  
+      12A      1.253554    13A      1.444876    14A      1.476958  
+      15A      1.675152    16A      1.867645    17A      1.935173  
+      18A      2.451431    19A      2.489038    20A      3.286338  
+      21A      3.339125    22A      3.510967    23A      3.865989  
+      24A      4.148029  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -76.02672862180600
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375748709706386
+    Two-Electron Energy =                  37.9234597915748353
+    Total Energy =                        -76.0267286218060008
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1669
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8096     Total:     0.8096
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0579     Total:     2.0579
+
+
+*** tstop() called on south at Thu Dec  2 17:50:52 2021
+Module time:
+	user time   =       1.87 seconds =       0.03 minutes
+	system time =       0.62 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      68.86 seconds =       1.15 minutes
+	system time =      27.84 seconds =       0.46 minutes
+	total time  =         46 seconds =       0.77 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Thu Dec  2 17:50:52 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.50 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02672862180600
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20394724679250
+	DF-MP2 Total Energy (a.u.)         :   -76.23067586859851
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2394012306     -7.62e+01       5.73e-04         2.84e-03        1.23e-04 
+   2     -76.2396082207     -2.07e-04       1.60e-04         7.04e-04        6.49e-05 
+   3     -76.2396332594     -2.50e-05       1.63e-05         7.12e-05        6.28e-06 
+   4     -76.2396339025     -6.43e-07       3.59e-06         1.91e-05        1.97e-06 
+   5     -76.2396339285     -2.61e-08       3.83e-07         2.44e-06        1.90e-07 
+   6     -76.2396339290     -5.10e-10       5.61e-08         4.50e-07        3.69e-08 
+   7     -76.2396339291     -1.13e-11       8.69e-09         4.23e-08        9.41e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02601922238091
+	DF-REMP Correlation Energy (a.u.)  :    -0.21361469808107
+	DF-REMP Total Energy (a.u.)        :   -76.23067586859851
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180600
+	REF Energy (a.u.)                  :   -76.02601922238091
+	DF-OREMP Correlation Energy (a.u.) :    -0.21290530724660
+	Edforemp - Eref (a.u.)             :    -0.21361470667169
+	DF-OREMP Total Energy (a.u.)       :   -76.23963392905260
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 17:51:08 2021
+Module time:
+	user time   =      24.55 seconds =       0.41 minutes
+	system time =       9.68 seconds =       0.16 minutes
+	total time  =         16 seconds =       0.27 minutes
+Total time:
+	user time   =      93.60 seconds =       1.56 minutes
+	system time =      37.58 seconds =       0.63 minutes
+	total time  =         62 seconds =       1.03 minutes
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:08 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Thu Dec  2 17:51:08 2021
+Module time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.17 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      93.93 seconds =       1.57 minutes
+	system time =      37.75 seconds =       0.63 minutes
+	total time  =         62 seconds =       1.03 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.012728281086
+       2       -0.000000000000     0.002453429980    -0.006364140543
+       3        0.000000000000    -0.002453429980    -0.006364140543
+
+    OREMP(0.20) Total Energy..............................................................PASSED
+    OREMP(0.20) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:08 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51050601860280   -7.55105e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95396440048312   -4.43458e-01   1.74099e-02 DIIS
+   @DF-RHF iter   2:   -76.00724905192097   -5.32847e-02   9.94895e-03 DIIS
+   @DF-RHF iter   3:   -76.02632264302764   -1.90736e-02   9.08408e-04 DIIS
+   @DF-RHF iter   4:   -76.02670841043160   -3.85767e-04   2.08342e-04 DIIS
+   @DF-RHF iter   5:   -76.02672767732807   -1.92669e-05   3.82796e-05 DIIS
+   @DF-RHF iter   6:   -76.02672859528970   -9.17962e-07   6.10645e-06 DIIS
+   @DF-RHF iter   7:   -76.02672862124921   -2.59595e-08   8.54412e-07 DIIS
+   @DF-RHF iter   8:   -76.02672862177270   -5.23499e-10   1.98130e-07 DIIS
+   @DF-RHF iter   9:   -76.02672862180520   -3.25002e-11   3.37707e-08 DIIS
+   @DF-RHF iter  10:   -76.02672862180604   -8.38440e-13   2.77585e-09 DIIS
+   @DF-RHF iter  11:   -76.02672862180603    1.42109e-14   4.86617e-10 DIIS
+   @DF-RHF iter  12:   -76.02672862180601    1.42109e-14   2.81763e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336338     3A     -0.698827  
+       4A     -0.566491     5A     -0.493092  
+
+    Virtual:                                                              
+
+       6A      0.185444     7A      0.256143     8A      0.788717  
+       9A      0.853857    10A      1.163774    11A      1.200480  
+      12A      1.253554    13A      1.444876    14A      1.476958  
+      15A      1.675152    16A      1.867645    17A      1.935173  
+      18A      2.451431    19A      2.489038    20A      3.286338  
+      21A      3.339125    22A      3.510967    23A      3.865989  
+      24A      4.148029  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -76.02672862180601
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375748709706386
+    Two-Electron Energy =                  37.9234597915748139
+    Total Energy =                        -76.0267286218060150
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1669
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8096     Total:     0.8096
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0579     Total:     2.0579
+
+
+*** tstop() called on south at Thu Dec  2 17:51:10 2021
+Module time:
+	user time   =       2.84 seconds =       0.05 minutes
+	system time =       0.61 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      97.02 seconds =       1.62 minutes
+	system time =      38.52 seconds =       0.64 minutes
+	total time  =         64 seconds =       1.07 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:10 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.50 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02672862180601
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20394724679250
+	DF-MP2 Total Energy (a.u.)         :   -76.23067586859852
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2380811323     -7.62e+01       5.07e-04         2.50e-03        1.08e-04 
+   2     -76.2382023540     -1.21e-04       1.25e-04         5.65e-04        3.45e-05 
+   3     -76.2382132817     -1.09e-05       1.02e-05         4.09e-05        2.24e-06 
+   4     -76.2382134627     -1.81e-07       2.09e-06         1.08e-05        1.08e-06 
+   5     -76.2382134683     -5.62e-09       1.95e-07         1.23e-06        1.38e-07 
+   6     -76.2382134684     -8.03e-11       2.74e-08         1.98e-07        1.77e-08 
+   7     -76.2382134684     -1.35e-12       3.19e-09         1.30e-08        3.09e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02600922469919
+	DF-REMP Correlation Energy (a.u.)  :    -0.21220424138712
+	DF-REMP Total Energy (a.u.)        :   -76.23067586859852
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180601
+	REF Energy (a.u.)                  :   -76.02600922469919
+	DF-OREMP Correlation Energy (a.u.) :    -0.21148484657158
+	Edforemp - Eref (a.u.)             :    -0.21220424367840
+	DF-OREMP Total Energy (a.u.)       :   -76.23821346837759
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 17:51:24 2021
+Module time:
+	user time   =      24.13 seconds =       0.40 minutes
+	system time =       9.54 seconds =       0.16 minutes
+	total time  =         14 seconds =       0.23 minutes
+Total time:
+	user time   =     121.35 seconds =       2.02 minutes
+	system time =      48.10 seconds =       0.80 minutes
+	total time  =         78 seconds =       1.30 minutes
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:24 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Thu Dec  2 17:51:24 2021
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.25 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     121.73 seconds =       2.03 minutes
+	system time =      48.35 seconds =       0.81 minutes
+	total time  =         78 seconds =       1.30 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.012438548445
+       2       -0.000000000000     0.002229197715    -0.006219274222
+       3        0.000000000000    -0.002229197715    -0.006219274222
+
+    OREMP(0.30) Total Energy..............................................................PASSED
+    OREMP(0.30) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:24 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:   -75.51050601860275   -7.55105e+01   0.00000e+00 
+   @DF-RHF iter   1:   -75.95396440048314   -4.43458e-01   1.74099e-02 DIIS
+   @DF-RHF iter   2:   -76.00724905192094   -5.32847e-02   9.94895e-03 DIIS
+   @DF-RHF iter   3:   -76.02632264302760   -1.90736e-02   9.08408e-04 DIIS
+   @DF-RHF iter   4:   -76.02670841043162   -3.85767e-04   2.08342e-04 DIIS
+   @DF-RHF iter   5:   -76.02672767732814   -1.92669e-05   3.82796e-05 DIIS
+   @DF-RHF iter   6:   -76.02672859528971   -9.17962e-07   6.10645e-06 DIIS
+   @DF-RHF iter   7:   -76.02672862124919   -2.59595e-08   8.54412e-07 DIIS
+   @DF-RHF iter   8:   -76.02672862177266   -5.23471e-10   1.98130e-07 DIIS
+   @DF-RHF iter   9:   -76.02672862180515   -3.24860e-11   3.37707e-08 DIIS
+   @DF-RHF iter  10:   -76.02672862180611   -9.66338e-13   2.77585e-09 DIIS
+   @DF-RHF iter  11:   -76.02672862180604    7.10543e-14   4.86617e-10 DIIS
+   @DF-RHF iter  12:   -76.02672862180603    1.42109e-14   2.81763e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336338     3A     -0.698827  
+       4A     -0.566491     5A     -0.493092  
+
+    Virtual:                                                              
+
+       6A      0.185444     7A      0.256143     8A      0.788717  
+       9A      0.853857    10A      1.163774    11A      1.200480  
+      12A      1.253554    13A      1.444876    14A      1.476958  
+      15A      1.675152    16A      1.867645    17A      1.935173  
+      18A      2.451431    19A      2.489038    20A      3.286338  
+      21A      3.339125    22A      3.510967    23A      3.865989  
+      24A      4.148029  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @DF-RHF Final Energy:   -76.02672862180603
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375748709706528
+    Two-Electron Energy =                  37.9234597915748282
+    Total Energy =                        -76.0267286218060150
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1669
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8096     Total:     0.8096
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0579     Total:     2.0579
+
+
+*** tstop() called on south at Thu Dec  2 17:51:26 2021
+Module time:
+	user time   =       2.52 seconds =       0.04 minutes
+	system time =       0.94 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     124.55 seconds =       2.08 minutes
+	system time =      49.42 seconds =       0.82 minutes
+	total time  =         80 seconds =       1.33 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:26 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'HF'
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  0    5    19    0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.50 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180603
+	REF Energy (a.u.)                  :   -76.02672862180603
+	DF-MP2 Correlation Energy (a.u.)   :    -0.20394724679250
+	DF-MP2 Total Energy (a.u.)         :   -76.23067586859854
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -76.2315698579     -7.62e+01       2.18e-04         8.18e-04        3.03e-05 
+   2     -76.2315718020     -1.94e-06       1.74e-05         8.49e-05        1.91e-06 
+   3     -76.2315718176     -1.56e-08       1.34e-06         7.06e-06        8.65e-08 
+   4     -76.2315718177     -1.11e-10       1.22e-07         7.36e-07        1.53e-08 
+   5     -76.2315718177     -8.10e-13       1.36e-09         7.88e-09        1.33e-10 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02672862180603
+	REF Energy (a.u.)                  :   -76.02580970062813
+	DF-REMP Correlation Energy (a.u.)  :    -0.20576211706345
+	DF-REMP Total Energy (a.u.)        :   -76.23067586859854
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -76.02672862180603
+	REF Energy (a.u.)                  :   -76.02580970062813
+	DF-OREMP Correlation Energy (a.u.) :    -0.20484319588485
+	Edforemp - Eref (a.u.)             :    -0.20576211706275
+	DF-OREMP Total Energy (a.u.)       :   -76.23157181769088
+	======================================================================= 
+
+
+*** tstop() called on south at Thu Dec  2 17:51:37 2021
+Module time:
+	user time   =      18.34 seconds =       0.31 minutes
+	system time =       7.44 seconds =       0.12 minutes
+	total time  =         11 seconds =       0.18 minutes
+Total time:
+	user time   =     143.08 seconds =       2.38 minutes
+	system time =      56.91 seconds =       0.95 minutes
+	total time  =         91 seconds =       1.52 minutes
+
+*** tstart() called on south
+*** at Thu Dec  2 17:51:37 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Thu Dec  2 17:51:37 2021
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     143.48 seconds =       2.39 minutes
+	system time =      57.11 seconds =       0.95 minutes
+	total time  =         91 seconds =       1.52 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.013476662939
+       2       -0.000000000000     0.002449235008    -0.006738331469
+       3        0.000000000000    -0.002449235008    -0.006738331469
+
+    OREMP(1.00) Total Energy..............................................................PASSED
+    OREMP(1.00) Analytic gradients........................................................PASSED
+
+    Psi4 stopped on: Thursday, 02 December 2021 05:51PM
+    Psi4 wall time for execution: 0:01:31.80
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dforemp-engrad2/CMakeLists.txt
+++ b/tests/dforemp-engrad2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dforemp-engrad2 "psi;dfocc")

--- a/tests/dforemp-engrad2/input.dat
+++ b/tests/dforemp-engrad2/input.dat
@@ -1,0 +1,105 @@
+#^! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O+ molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80435339733860,  #TEST
+                     "0.10": -75.80180406723521,  #TEST
+                     "0.20": -75.79949516378888,  #TEST
+                     "0.30": -75.79737363666753,  #TEST
+                     "1.00": -75.78578728213620}  #TEST
+
+   
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  guess sad
+  scf_type df
+  freeze_core false
+  wfn_type oremp
+  cc_type df
+  mp_type df
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [ 0.000000000000,    -0.000000000000,     0.049138329774 ],
+            [ 0.000000000000,     0.041865124629,    -0.024569164887 ],  
+            [ 0.000000000000,    -0.041865124629,    -0.024569164887 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.048212641668  ],
+            [  0.000000000000,     0.041343367016,    -0.024106320834  ],
+            [  0.000000000000,    -0.041343367016,    -0.024106320834  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,     0.000000000000,     0.047556410036 ],
+            [  0.000000000000,     0.040973151761,    -0.023778205018 ],
+            [  0.000000000000,    -0.040973151761,    -0.023778205018 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.20) Analytic gradients")  #TEST
+
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.047075323522  ],
+            [  0.000000000000,     0.040701828521,    -0.023537661761  ],
+            [  0.000000000000,    -0.040701828521,    -0.023537661761  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.30) Analytic gradients")  #TEST
+
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.046007417724  ],
+            [  0.000000000000,     0.040091039970,    -0.023003708862  ],
+            [  0.000000000000,    -0.040091039970,    -0.023003708862  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(1.00) Analytic gradients")  #TEST

--- a/tests/dforemp-engrad2/output.ref
+++ b/tests/dforemp-engrad2/output.ref
@@ -1,0 +1,2806 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Friday, 03 December 2021 09:54AM
+
+    Process ID: 19912
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#^! density fitted OO-REMP/cc-pVDZ engrad single points for the H2O+ molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80435339733860,  #TEST
+                     "0.10": -75.80180406723521,  #TEST
+                     "0.20": -75.79949516378888,  #TEST
+                     "0.30": -75.79737363666753,  #TEST
+                     "1.00": -75.78578728213620}  #TEST
+
+   
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  guess sad
+  scf_type df
+  freeze_core false
+  wfn_type oremp
+  cc_type df
+  mp_type df
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [ 0.000000000000,    -0.000000000000,     0.049138329774 ],
+            [ 0.000000000000,     0.041865124629,    -0.024569164887 ],  
+            [ 0.000000000000,    -0.041865124629,    -0.024569164887 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.048212641668  ],
+            [  0.000000000000,     0.041343367016,    -0.024106320834  ],
+            [  0.000000000000,    -0.041343367016,    -0.024106320834  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,     0.000000000000,     0.047556410036 ],
+            [  0.000000000000,     0.040973151761,    -0.023778205018 ],
+            [  0.000000000000,    -0.040973151761,    -0.023778205018 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.20) Analytic gradients")  #TEST
+
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.047075323522  ],
+            [  0.000000000000,     0.040701828521,    -0.023537661761  ],
+            [  0.000000000000,    -0.040701828521,    -0.023537661761  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(0.30) Analytic gradients")  #TEST
+
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [  0.000000000000,    -0.000000000000,     0.046007417724  ],
+            [  0.000000000000,     0.040091039970,    -0.023003708862  ],
+            [  0.000000000000,    -0.040091039970,    -0.023003708862  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "DF-OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "DF-OREMP(1.00) Analytic gradients")  #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Fri Dec  3 09:54:16 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51050601860277   -7.55105e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.59294639597749   -8.24404e-02   1.13735e-02 DIIS
+   @DF-UHF iter   2:   -75.62900900759620   -3.60626e-02   3.07844e-03 DIIS
+   @DF-UHF iter   3:   -75.63139688569717   -2.38788e-03   1.08997e-03 DIIS
+   @DF-UHF iter   4:   -75.63178136272290   -3.84477e-04   3.53717e-04 DIIS
+   @DF-UHF iter   5:   -75.63185562798994   -7.42653e-05   1.56822e-04 DIIS
+   @DF-UHF iter   6:   -75.63187622084774   -2.05929e-05   4.78877e-05 DIIS
+   @DF-UHF iter   7:   -75.63187837087391   -2.15003e-06   8.09716e-06 DIIS
+   @DF-UHF iter   8:   -75.63187842089773   -5.00238e-08   1.25163e-06 DIIS
+   @DF-UHF iter   9:   -75.63187842175866   -8.60922e-10   2.49798e-07 DIIS
+   @DF-UHF iter  10:   -75.63187842179670   -3.80425e-11   4.18278e-08 DIIS
+   @DF-UHF iter  11:   -75.63187842179774   -1.03739e-12   7.40067e-09 DIIS
+   @DF-UHF iter  12:   -75.63187842179781   -7.10543e-14   1.99116e-09 DIIS
+   @DF-UHF iter  13:   -75.63187842179777    4.26326e-14   2.14839e-10 DIIS
+   @DF-UHF iter  14:   -75.63187842179784   -7.10543e-14   3.95693e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.086622938E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560866229E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140129     2A     -1.913846     3A     -1.218292  
+       4A     -1.130136     5A     -1.097755  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141728     7A     -0.058356     8A      0.392733  
+       9A      0.447093    10A      0.672549    11A      0.714888  
+      12A      0.827233    13A      1.025025    14A      1.040296  
+      15A      1.239335    16A      1.385352    17A      1.532253  
+      18A      1.995954    19A      2.004380    20A      2.723530  
+      21A      2.774365    22A      3.001680    23A      3.327136  
+      24A      3.653630  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095058     2A     -1.757784     3A     -1.180072  
+       4A     -1.045869  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313551     6A     -0.127663     7A     -0.050164  
+       8A      0.391550     9A      0.463552    10A      0.736224  
+      11A      0.844608    12A      0.870092    13A      1.035822  
+      14A      1.070628    15A      1.269437    16A      1.437920  
+      17A      1.529013    18A      2.007490    19A      2.060046  
+      20A      2.827128    21A      2.878707    22A      3.033262  
+      23A      3.405682    24A      3.671275  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @DF-UHF Final Energy:   -75.63187842179784
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0595876662135311
+    Two-Electron Energy =                  33.2403227868258853
+    Total Energy =                        -75.6318784217978362
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980713
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019287
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003014
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.0133
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.9898     Total:     0.9898
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.5158     Total:     2.5158
+
+
+*** tstop() called on south at Fri Dec  3 09:54:17 2021
+Module time:
+	user time   =       3.36 seconds =       0.06 minutes
+	system time =       1.04 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.36 seconds =       0.06 minutes
+	system time =       1.04 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Fri Dec  3 09:54:17 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.00 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63187842179784
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444431972092
+	Alpha-Beta Contribution (a.u.)     :    -0.11734018147628
+	Beta-Beta Contribution (a.u.)      :    -0.01140514185496
+	Scaled_SS Correlation Energy (a.u.):    -0.01194982052529
+	Scaled_OS Correlation Energy (a.u.):    -0.14080821777153
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78463646009467
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78442065771699
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69497347417138
+	DF-MP2 Correlation Energy (a.u.)   :    -0.15318964305216
+	DF-MP2 Total Energy (a.u.)         :   -75.78506806484999
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.8034735567     -7.58e+01       2.13e-03         1.11e-02        3.15e-04 
+   2     -75.8041074152     -6.34e-04       8.21e-04         3.31e-03        1.23e-04 
+   3     -75.8042875045     -1.80e-04       5.32e-04         1.98e-03        4.94e-05 
+   4     -75.8043305513     -4.30e-05       1.64e-04         6.52e-04        2.88e-05 
+   5     -75.8043488203     -1.83e-05       4.19e-05         1.91e-04        1.11e-05 
+   6     -75.8043530919     -4.27e-06       8.23e-06         4.49e-05        3.60e-06 
+   7     -75.8043533672     -2.75e-07       3.18e-06         1.57e-05        1.16e-06 
+   8     -75.8043533920     -2.48e-08       1.34e-06         7.35e-06        4.80e-07 
+   9     -75.8043533966     -4.58e-09       4.21e-07         3.34e-06        1.89e-07 
+  10     -75.8043533973     -6.68e-10       2.51e-07         1.07e-06        4.35e-08 
+  11     -75.8043533973     -7.72e-11       1.74e-07         7.09e-07        2.29e-08 
+  12     -75.8043533973     -8.37e-12       5.42e-08         2.34e-07        9.70e-09 
+  13     -75.8043533973     -1.48e-12       9.90e-09         7.16e-08        3.66e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63110791051255
+	Alpha-Alpha Contribution (a.u.)    :    -0.02384402017421
+	Alpha-Beta Contribution (a.u.)     :    -0.13862177927709
+	Beta-Beta Contribution (a.u.)      :    -0.01077970351959
+	DF-REMP Correlation Energy (a.u.)  :    -0.17324550297090
+	DF-REMP Total Energy (a.u.)        :   -75.78506806484999
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63110791051255
+	DF-OREMP Correlation Energy (a.u.) :    -0.17247497554075
+	Edforemp - Eref (a.u.)             :    -0.17324548682603
+	DF-OREMP Total Energy (a.u.)       :   -75.80435339733859
+	======================================================================= 
+
+
+*** tstop() called on south at Fri Dec  3 09:54:55 2021
+Module time:
+	user time   =      89.32 seconds =       1.49 minutes
+	system time =      35.83 seconds =       0.60 minutes
+	total time  =         38 seconds =       0.63 minutes
+Total time:
+	user time   =      92.92 seconds =       1.55 minutes
+	system time =      36.95 seconds =       0.62 minutes
+	total time  =         39 seconds =       0.65 minutes
+
+*** tstart() called on south
+*** at Fri Dec  3 09:54:55 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Fri Dec  3 09:54:56 2021
+Module time:
+	user time   =       0.57 seconds =       0.01 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      93.49 seconds =       1.56 minutes
+	system time =      37.26 seconds =       0.62 minutes
+	total time  =         40 seconds =       0.67 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.049138329774
+       2        0.000000000000     0.041865124629    -0.024569164887
+       3        0.000000000000    -0.041865124629    -0.024569164887
+
+    DF-OREMP(0.00) Total Energy...........................................................PASSED
+    DF-OREMP(0.00) Analytic gradients.....................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Fri Dec  3 09:54:56 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51050601860277   -7.55105e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.59294639597749   -8.24404e-02   1.13735e-02 DIIS
+   @DF-UHF iter   2:   -75.62900900759632   -3.60626e-02   3.07844e-03 DIIS
+   @DF-UHF iter   3:   -75.63139688569730   -2.38788e-03   1.08997e-03 DIIS
+   @DF-UHF iter   4:   -75.63178136272298   -3.84477e-04   3.53717e-04 DIIS
+   @DF-UHF iter   5:   -75.63185562799003   -7.42653e-05   1.56822e-04 DIIS
+   @DF-UHF iter   6:   -75.63187622084781   -2.05929e-05   4.78877e-05 DIIS
+   @DF-UHF iter   7:   -75.63187837087395   -2.15003e-06   8.09716e-06 DIIS
+   @DF-UHF iter   8:   -75.63187842089778   -5.00238e-08   1.25163e-06 DIIS
+   @DF-UHF iter   9:   -75.63187842175870   -8.60922e-10   2.49798e-07 DIIS
+   @DF-UHF iter  10:   -75.63187842179674   -3.80425e-11   4.18278e-08 DIIS
+   @DF-UHF iter  11:   -75.63187842179784   -1.09424e-12   7.40067e-09 DIIS
+   @DF-UHF iter  12:   -75.63187842179785   -1.42109e-14   1.99116e-09 DIIS
+   @DF-UHF iter  13:   -75.63187842179785    0.00000e+00   2.14839e-10 DIIS
+   @DF-UHF iter  14:   -75.63187842179786   -1.42109e-14   3.95692e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.086622938E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560866229E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140129     2A     -1.913846     3A     -1.218292  
+       4A     -1.130136     5A     -1.097755  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141728     7A     -0.058356     8A      0.392733  
+       9A      0.447093    10A      0.672549    11A      0.714888  
+      12A      0.827233    13A      1.025025    14A      1.040296  
+      15A      1.239335    16A      1.385352    17A      1.532253  
+      18A      1.995954    19A      2.004380    20A      2.723530  
+      21A      2.774365    22A      3.001680    23A      3.327136  
+      24A      3.653630  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095058     2A     -1.757784     3A     -1.180072  
+       4A     -1.045869  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313551     6A     -0.127663     7A     -0.050164  
+       8A      0.391550     9A      0.463552    10A      0.736224  
+      11A      0.844608    12A      0.870092    13A      1.035822  
+      14A      1.070628    15A      1.269437    16A      1.437920  
+      17A      1.529013    18A      2.007490    19A      2.060046  
+      20A      2.827128    21A      2.878707    22A      3.033262  
+      23A      3.405682    24A      3.671275  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @DF-UHF Final Energy:   -75.63187842179786
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0595876662135169
+    Two-Electron Energy =                  33.2403227868258426
+    Total Energy =                        -75.6318784217978646
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980713
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019287
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003014
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0133
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9898     Total:     0.9898
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5158     Total:     2.5158
+
+
+*** tstop() called on south at Fri Dec  3 09:54:57 2021
+Module time:
+	user time   =       3.15 seconds =       0.05 minutes
+	system time =       1.09 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      96.92 seconds =       1.62 minutes
+	system time =      38.51 seconds =       0.64 minutes
+	total time  =         41 seconds =       0.68 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Fri Dec  3 09:54:57 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.00 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179786
+	REF Energy (a.u.)                  :   -75.63187842179786
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444431972092
+	Alpha-Beta Contribution (a.u.)     :    -0.11734018147628
+	Beta-Beta Contribution (a.u.)      :    -0.01140514185496
+	Scaled_SS Correlation Energy (a.u.):    -0.01194982052529
+	Scaled_OS Correlation Energy (a.u.):    -0.14080821777153
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78463646009470
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78442065771702
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69497347417141
+	DF-MP2 Correlation Energy (a.u.)   :    -0.15318964305216
+	DF-MP2 Total Energy (a.u.)         :   -75.78506806485002
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.8012572401     -7.58e+01       2.10e-03         1.08e-02        2.84e-04 
+   2     -75.8016822454     -4.25e-04       7.85e-04         3.02e-03        9.14e-05 
+   3     -75.8017780648     -9.58e-05       5.05e-04         1.82e-03        3.61e-05 
+   4     -75.8017973884     -1.93e-05       1.40e-04         5.43e-04        1.83e-05 
+   5     -75.8018032419     -5.85e-06       3.52e-05         1.56e-04        6.64e-06 
+   6     -75.8018040343     -7.92e-07       6.18e-06         3.45e-05        1.46e-06 
+   7     -75.8018040644     -3.02e-08       1.39e-06         8.11e-06        4.36e-07 
+   8     -75.8018040668     -2.41e-09       5.23e-07         3.04e-06        1.60e-07 
+   9     -75.8018040672     -3.56e-10       1.33e-07         9.40e-07        5.07e-08 
+  10     -75.8018040672     -3.39e-11       5.94e-08         3.91e-07        1.46e-08 
+  11     -75.8018040672     -2.53e-12       3.44e-08         1.64e-07        4.42e-09 
+  12     -75.8018040672     -2.13e-13       6.59e-09         2.87e-08        1.68e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63187842179786
+	REF Energy (a.u.)                  :   -75.63113396307742
+	Alpha-Alpha Contribution (a.u.)    :    -0.02402034317159
+	Alpha-Beta Contribution (a.u.)     :    -0.13572627071408
+	Beta-Beta Contribution (a.u.)      :    -0.01092349352345
+	DF-REMP Correlation Energy (a.u.)  :    -0.17067010740912
+	DF-REMP Total Energy (a.u.)        :   -75.78506806485002
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179786
+	REF Energy (a.u.)                  :   -75.63113396307742
+	DF-OREMP Correlation Energy (a.u.) :    -0.16992564543732
+	Edforemp - Eref (a.u.)             :    -0.17067010415776
+	DF-OREMP Total Energy (a.u.)       :   -75.80180406723518
+	======================================================================= 
+
+
+*** tstop() called on south at Fri Dec  3 09:55:39 2021
+Module time:
+	user time   =      94.42 seconds =       1.57 minutes
+	system time =      38.17 seconds =       0.64 minutes
+	total time  =         42 seconds =       0.70 minutes
+Total time:
+	user time   =     191.55 seconds =       3.19 minutes
+	system time =      76.78 seconds =       1.28 minutes
+	total time  =         83 seconds =       1.38 minutes
+
+*** tstart() called on south
+*** at Fri Dec  3 09:55:39 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Fri Dec  3 09:55:40 2021
+Module time:
+	user time   =       0.79 seconds =       0.01 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     192.34 seconds =       3.21 minutes
+	system time =      77.23 seconds =       1.29 minutes
+	total time  =         84 seconds =       1.40 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.048212641668
+       2        0.000000000000     0.041343367016    -0.024106320834
+       3        0.000000000000    -0.041343367016    -0.024106320834
+
+    DF-OREMP(0.10) Total Energy...........................................................PASSED
+    DF-OREMP(0.10) Analytic gradients.....................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Fri Dec  3 09:55:40 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51050601860280   -7.55105e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.59294639597752   -8.24404e-02   1.13735e-02 DIIS
+   @DF-UHF iter   2:   -75.62900900759634   -3.60626e-02   3.07844e-03 DIIS
+   @DF-UHF iter   3:   -75.63139688569730   -2.38788e-03   1.08997e-03 DIIS
+   @DF-UHF iter   4:   -75.63178136272300   -3.84477e-04   3.53717e-04 DIIS
+   @DF-UHF iter   5:   -75.63185562799003   -7.42653e-05   1.56822e-04 DIIS
+   @DF-UHF iter   6:   -75.63187622084780   -2.05929e-05   4.78877e-05 DIIS
+   @DF-UHF iter   7:   -75.63187837087398   -2.15003e-06   8.09716e-06 DIIS
+   @DF-UHF iter   8:   -75.63187842089779   -5.00238e-08   1.25163e-06 DIIS
+   @DF-UHF iter   9:   -75.63187842175867   -8.60879e-10   2.49798e-07 DIIS
+   @DF-UHF iter  10:   -75.63187842179670   -3.80282e-11   4.18278e-08 DIIS
+   @DF-UHF iter  11:   -75.63187842179781   -1.10845e-12   7.40067e-09 DIIS
+   @DF-UHF iter  12:   -75.63187842179785   -4.26326e-14   1.99116e-09 DIIS
+   @DF-UHF iter  13:   -75.63187842179784    1.42109e-14   2.14839e-10 DIIS
+   @DF-UHF iter  14:   -75.63187842179785   -1.42109e-14   3.95692e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.086622938E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560866229E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140129     2A     -1.913846     3A     -1.218292  
+       4A     -1.130136     5A     -1.097755  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141728     7A     -0.058356     8A      0.392733  
+       9A      0.447093    10A      0.672549    11A      0.714888  
+      12A      0.827233    13A      1.025025    14A      1.040296  
+      15A      1.239335    16A      1.385352    17A      1.532253  
+      18A      1.995954    19A      2.004380    20A      2.723530  
+      21A      2.774365    22A      3.001680    23A      3.327136  
+      24A      3.653630  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095058     2A     -1.757784     3A     -1.180072  
+       4A     -1.045869  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313551     6A     -0.127663     7A     -0.050164  
+       8A      0.391550     9A      0.463552    10A      0.736224  
+      11A      0.844608    12A      0.870092    13A      1.035822  
+      14A      1.070628    15A      1.269437    16A      1.437920  
+      17A      1.529013    18A      2.007490    19A      2.060046  
+      20A      2.827128    21A      2.878707    22A      3.033262  
+      23A      3.405682    24A      3.671275  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @DF-UHF Final Energy:   -75.63187842179785
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0595876662135169
+    Two-Electron Energy =                  33.2403227868258497
+    Total Energy =                        -75.6318784217978646
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980713
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019287
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003014
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0133
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9898     Total:     0.9898
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5158     Total:     2.5158
+
+
+*** tstop() called on south at Fri Dec  3 09:55:41 2021
+Module time:
+	user time   =       3.53 seconds =       0.06 minutes
+	system time =       1.00 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     196.20 seconds =       3.27 minutes
+	system time =      78.39 seconds =       1.31 minutes
+	total time  =         85 seconds =       1.42 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Fri Dec  3 09:55:41 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.00 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63187842179785
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444431972092
+	Alpha-Beta Contribution (a.u.)     :    -0.11734018147628
+	Beta-Beta Contribution (a.u.)      :    -0.01140514185496
+	Scaled_SS Correlation Energy (a.u.):    -0.01194982052529
+	Scaled_OS Correlation Energy (a.u.):    -0.14080821777153
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78463646009469
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78442065771701
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69497347417139
+	DF-MP2 Correlation Energy (a.u.)   :    -0.15318964305216
+	DF-MP2 Total Energy (a.u.)         :   -75.78506806485001
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7991546194     -7.58e+01       2.07e-03         1.05e-02        2.13e-04 
+   2     -75.7994337377     -2.79e-04       7.55e-04         2.76e-03        5.16e-05 
+   3     -75.7994839493     -5.02e-05       4.80e-04         1.69e-03        2.67e-05 
+   4     -75.7994930685     -9.12e-06       1.24e-04         4.63e-04        5.46e-06 
+   5     -75.7994950112     -1.94e-06       3.09e-05         1.34e-04        3.01e-06 
+   6     -75.7994951603     -1.49e-07       5.43e-06         3.02e-05        5.16e-07 
+   7     -75.7994951635     -3.27e-09       1.07e-06         5.62e-06        1.48e-07 
+   8     -75.7994951638     -2.33e-10       2.69e-07         1.72e-06        4.96e-08 
+   9     -75.7994951638     -2.53e-11       6.14e-08         4.13e-07        1.33e-08 
+  10     -75.7994951638     -1.55e-12       1.78e-08         9.99e-08        1.84e-09 
+  11     -75.7994951638     -1.42e-13       8.93e-09         4.74e-08        8.61e-10 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63115122010167
+	Alpha-Alpha Contribution (a.u.)    :    -0.02416418079772
+	Alpha-Beta Contribution (a.u.)     :    -0.13313585595282
+	Beta-Beta Contribution (a.u.)      :    -0.01104390745993
+	DF-REMP Correlation Energy (a.u.)  :    -0.16834394421047
+	DF-REMP Total Energy (a.u.)        :   -75.78506806485001
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63115122010167
+	DF-OREMP Correlation Energy (a.u.) :    -0.16761674199105
+	Edforemp - Eref (a.u.)             :    -0.16834394368723
+	DF-OREMP Total Energy (a.u.)       :   -75.79949516378890
+	======================================================================= 
+
+
+*** tstop() called on south at Fri Dec  3 09:56:18 2021
+Module time:
+	user time   =      81.72 seconds =       1.36 minutes
+	system time =      33.60 seconds =       0.56 minutes
+	total time  =         37 seconds =       0.62 minutes
+Total time:
+	user time   =     278.13 seconds =       4.64 minutes
+	system time =     112.09 seconds =       1.87 minutes
+	total time  =        122 seconds =       2.03 minutes
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:18 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Fri Dec  3 09:56:18 2021
+Module time:
+	user time   =       0.65 seconds =       0.01 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     278.78 seconds =       4.65 minutes
+	system time =     112.40 seconds =       1.87 minutes
+	total time  =        122 seconds =       2.03 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.047556410036
+       2        0.000000000000     0.040973151761    -0.023778205018
+       3        0.000000000000    -0.040973151761    -0.023778205018
+
+    DF-OREMP(0.20) Total Energy...........................................................PASSED
+    DF-OREMP(0.20) Analytic gradients.....................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:18 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51050601860277   -7.55105e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.59294639597758   -8.24404e-02   1.13735e-02 DIIS
+   @DF-UHF iter   2:   -75.62900900759630   -3.60626e-02   3.07844e-03 DIIS
+   @DF-UHF iter   3:   -75.63139688569728   -2.38788e-03   1.08997e-03 DIIS
+   @DF-UHF iter   4:   -75.63178136272299   -3.84477e-04   3.53717e-04 DIIS
+   @DF-UHF iter   5:   -75.63185562799003   -7.42653e-05   1.56822e-04 DIIS
+   @DF-UHF iter   6:   -75.63187622084780   -2.05929e-05   4.78877e-05 DIIS
+   @DF-UHF iter   7:   -75.63187837087392   -2.15003e-06   8.09716e-06 DIIS
+   @DF-UHF iter   8:   -75.63187842089775   -5.00238e-08   1.25163e-06 DIIS
+   @DF-UHF iter   9:   -75.63187842175871   -8.60965e-10   2.49798e-07 DIIS
+   @DF-UHF iter  10:   -75.63187842179677   -3.80567e-11   4.18278e-08 DIIS
+   @DF-UHF iter  11:   -75.63187842179784   -1.06581e-12   7.40067e-09 DIIS
+   @DF-UHF iter  12:   -75.63187842179786   -2.84217e-14   1.99116e-09 DIIS
+   @DF-UHF iter  13:   -75.63187842179786    0.00000e+00   2.14839e-10 DIIS
+   @DF-UHF iter  14:   -75.63187842179784    2.84217e-14   3.95692e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.086622938E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560866229E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140129     2A     -1.913846     3A     -1.218292  
+       4A     -1.130136     5A     -1.097755  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141728     7A     -0.058356     8A      0.392733  
+       9A      0.447093    10A      0.672549    11A      0.714888  
+      12A      0.827233    13A      1.025025    14A      1.040296  
+      15A      1.239335    16A      1.385352    17A      1.532253  
+      18A      1.995954    19A      2.004380    20A      2.723530  
+      21A      2.774365    22A      3.001680    23A      3.327136  
+      24A      3.653630  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095058     2A     -1.757784     3A     -1.180072  
+       4A     -1.045869  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313551     6A     -0.127663     7A     -0.050164  
+       8A      0.391550     9A      0.463552    10A      0.736224  
+      11A      0.844608    12A      0.870092    13A      1.035822  
+      14A      1.070628    15A      1.269437    16A      1.437920  
+      17A      1.529013    18A      2.007490    19A      2.060046  
+      20A      2.827128    21A      2.878707    22A      3.033262  
+      23A      3.405682    24A      3.671275  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @DF-UHF Final Energy:   -75.63187842179784
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0595876662134458
+    Two-Electron Energy =                  33.2403227868258000
+    Total Energy =                        -75.6318784217978362
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980713
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019287
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003014
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0133
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9898     Total:     0.9898
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5158     Total:     2.5158
+
+
+*** tstop() called on south at Fri Dec  3 09:56:19 2021
+Module time:
+	user time   =       3.61 seconds =       0.06 minutes
+	system time =       1.21 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     282.65 seconds =       4.71 minutes
+	system time =     113.77 seconds =       1.90 minutes
+	total time  =        123 seconds =       2.05 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:20 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.00 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63187842179784
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444431972092
+	Alpha-Beta Contribution (a.u.)     :    -0.11734018147628
+	Beta-Beta Contribution (a.u.)      :    -0.01140514185496
+	Scaled_SS Correlation Energy (a.u.):    -0.01194982052529
+	Scaled_OS Correlation Energy (a.u.):    -0.14080821777153
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78463646009467
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78442065771699
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69497347417138
+	DF-MP2 Correlation Energy (a.u.)   :    -0.15318964305216
+	DF-MP2 Total Energy (a.u.)         :   -75.78506806484999
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7971599489     -7.58e+01       2.04e-03         1.01e-02        2.23e-04 
+   2     -75.7973410114     -1.81e-04       7.32e-04         2.80e-03        5.30e-05 
+   3     -75.7973678769     -2.69e-05       4.56e-04         1.59e-03        1.88e-05 
+   4     -75.7973727769     -4.90e-06       1.12e-04         4.18e-04        6.38e-06 
+   5     -75.7973735885     -8.12e-07       2.71e-05         1.18e-04        8.44e-07 
+   6     -75.7973736350     -4.66e-08       4.59e-06         2.53e-05        1.89e-07 
+   7     -75.7973736366     -1.52e-09       7.85e-07         3.97e-06        9.96e-08 
+   8     -75.7973736367     -1.01e-10       1.52e-07         6.54e-07        2.68e-08 
+   9     -75.7973736367     -5.74e-12       2.92e-08         1.21e-07        4.46e-09 
+  10     -75.7973736367     -1.28e-13       9.51e-09         3.75e-08        1.19e-09 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63116247473275
+	Alpha-Alpha Contribution (a.u.)    :    -0.02428102043438
+	Alpha-Beta Contribution (a.u.)     :    -0.13078515742999
+	Beta-Beta Contribution (a.u.)      :    -0.01114498600651
+	DF-REMP Correlation Energy (a.u.)  :    -0.16621116387088
+	DF-REMP Total Energy (a.u.)        :   -75.78506806484999
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179784
+	REF Energy (a.u.)                  :   -75.63116247473275
+	DF-OREMP Correlation Energy (a.u.) :    -0.16549521486969
+	Edforemp - Eref (a.u.)             :    -0.16621116193478
+	DF-OREMP Total Energy (a.u.)       :   -75.79737363666753
+	======================================================================= 
+
+
+*** tstop() called on south at Fri Dec  3 09:56:51 2021
+Module time:
+	user time   =      77.31 seconds =       1.29 minutes
+	system time =      30.99 seconds =       0.52 minutes
+	total time  =         31 seconds =       0.52 minutes
+Total time:
+	user time   =     360.15 seconds =       6.00 minutes
+	system time =     144.88 seconds =       2.41 minutes
+	total time  =        155 seconds =       2.58 minutes
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:51 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Fri Dec  3 09:56:51 2021
+Module time:
+	user time   =       0.60 seconds =       0.01 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     360.75 seconds =       6.01 minutes
+	system time =     145.17 seconds =       2.42 minutes
+	total time  =        155 seconds =       2.58 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.047075323522
+       2        0.000000000000     0.040701828521    -0.023537661761
+       3        0.000000000000    -0.040701828521    -0.023537661761
+
+    DF-OREMP(0.30) Total Energy...........................................................PASSED
+    DF-OREMP(0.30) Analytic gradients.....................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+    For method 'OREMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:51 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 37
+    Number of basis functions: 113
+    Number of Cartesian functions: 133
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -75.51050601860275   -7.55105e+01   0.00000e+00 
+   @DF-UHF iter   1:   -75.59294639597756   -8.24404e-02   1.13735e-02 DIIS
+   @DF-UHF iter   2:   -75.62900900759630   -3.60626e-02   3.07844e-03 DIIS
+   @DF-UHF iter   3:   -75.63139688569728   -2.38788e-03   1.08997e-03 DIIS
+   @DF-UHF iter   4:   -75.63178136272300   -3.84477e-04   3.53717e-04 DIIS
+   @DF-UHF iter   5:   -75.63185562799003   -7.42653e-05   1.56822e-04 DIIS
+   @DF-UHF iter   6:   -75.63187622084784   -2.05929e-05   4.78877e-05 DIIS
+   @DF-UHF iter   7:   -75.63187837087392   -2.15003e-06   8.09716e-06 DIIS
+   @DF-UHF iter   8:   -75.63187842089782   -5.00239e-08   1.25163e-06 DIIS
+   @DF-UHF iter   9:   -75.63187842175874   -8.60922e-10   2.49798e-07 DIIS
+   @DF-UHF iter  10:   -75.63187842179673   -3.79856e-11   4.18278e-08 DIIS
+   @DF-UHF iter  11:   -75.63187842179781   -1.08002e-12   7.40067e-09 DIIS
+   @DF-UHF iter  12:   -75.63187842179782   -1.42109e-14   1.99116e-09 DIIS
+   @DF-UHF iter  13:   -75.63187842179784   -1.42109e-14   2.14839e-10 DIIS
+   @DF-UHF iter  14:   -75.63187842179785   -1.42109e-14   3.95692e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.086622938E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560866229E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140129     2A     -1.913846     3A     -1.218292  
+       4A     -1.130136     5A     -1.097755  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141728     7A     -0.058356     8A      0.392733  
+       9A      0.447093    10A      0.672549    11A      0.714888  
+      12A      0.827233    13A      1.025025    14A      1.040296  
+      15A      1.239335    16A      1.385352    17A      1.532253  
+      18A      1.995954    19A      2.004380    20A      2.723530  
+      21A      2.774365    22A      3.001680    23A      3.327136  
+      24A      3.653630  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095058     2A     -1.757784     3A     -1.180072  
+       4A     -1.045869  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313551     6A     -0.127663     7A     -0.050164  
+       8A      0.391550     9A      0.463552    10A      0.736224  
+      11A      0.844608    12A      0.870092    13A      1.035822  
+      14A      1.070628    15A      1.269437    16A      1.437920  
+      17A      1.529013    18A      2.007490    19A      2.060046  
+      20A      2.827128    21A      2.878707    22A      3.033262  
+      23A      3.405682    24A      3.671275  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @DF-UHF Final Energy:   -75.63187842179785
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0595876662135169
+    Two-Electron Energy =                  33.2403227868258497
+    Total Energy =                        -75.6318784217978646
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991849
+  HONO-1 :    4  A 1.9980713
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019287
+  LUNO+1 :    7  A 0.0008151
+  LUNO+2 :    8  A 0.0003014
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0133
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9898     Total:     0.9898
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5158     Total:     2.5158
+
+
+*** tstop() called on south at Fri Dec  3 09:56:52 2021
+Module time:
+	user time   =       2.16 seconds =       0.04 minutes
+	system time =       0.82 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     363.19 seconds =       6.05 minutes
+	system time =     146.18 seconds =       2.44 minutes
+	total time  =        156 seconds =       2.60 minutes
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Fri Dec  3 09:56:53 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => (empty)          
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => DF              !
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	Warning: cc_lambda option is changed to TRUE
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                     DF-OREMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO Hessian type is changed to 'APPROX_DIAG'
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  0     5     4    19     20     0
+	Reading DF integrals from disk ...
+	Number of basis functions in the DF-HF basis: 113
+	Number of basis functions in the DF-CC basis: 136
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      1.00 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.77 MB 
+	Memory requirement for Wabef term     :      0.87 MB 
+
+	Computing DF-MP2 energy using SCF MOs (Canonical DF-MP2)... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63187842179785
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444431972092
+	Alpha-Beta Contribution (a.u.)     :    -0.11734018147628
+	Beta-Beta Contribution (a.u.)      :    -0.01140514185496
+	Scaled_SS Correlation Energy (a.u.):    -0.01194982052529
+	Scaled_OS Correlation Energy (a.u.):    -0.14080821777153
+	DF-SCS-MP2 Total Energy (a.u.)     :   -75.78463646009469
+	DF-SOS-MP2 Total Energy (a.u.)     :   -75.78442065771701
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -75.69497347417139
+	DF-MP2 Correlation Energy (a.u.)   :    -0.15318964305216
+	DF-MP2 Total Energy (a.u.)         :   -75.78506806485001
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing DF-OREMP iterations... =========================== 
+ ============================================================================== 
+	            Minimizing DF-REMP-L Functional 
+	            ------------------------------ 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+	successfully fired up coupled DIIS...
+   1     -75.7857380148     -7.58e+01       1.86e-03         7.44e-03        2.22e-05 
+   2     -75.7857778328     -3.98e-05       6.91e-04         3.79e-03        4.01e-06 
+   3     -75.7857848854     -7.05e-06       3.51e-04         1.19e-03        1.70e-06 
+   4     -75.7857870466     -2.16e-06       7.40e-05         2.67e-04        4.92e-07 
+   5     -75.7857872757     -2.29e-07       1.07e-05         5.78e-05        1.25e-07 
+   6     -75.7857872821     -6.34e-09       1.19e-06         5.56e-06        1.77e-08 
+   7     -75.7857872821     -4.66e-11       2.53e-07         9.20e-07        2.95e-09 
+   8     -75.7857872821     -2.10e-12       5.76e-08         2.30e-07        6.26e-10 
+   9     -75.7857872821     -2.84e-14       1.08e-08         4.26e-08        1.10e-10 
+  10     -75.7857872821     -2.84e-14       1.49e-09         6.71e-09        1.79e-11 
+
+ ============================================================================== 
+ ======================== DF-OREMP ITERATIONS ARE CONVERGED =================== 
+ ============================================================================== 
+
+	Computing DF-REMP energy using optimized MOs... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63115702739776
+	Alpha-Alpha Contribution (a.u.)    :    -0.02462910808628
+	Alpha-Beta Contribution (a.u.)     :    -0.11848104544936
+	Beta-Beta Contribution (a.u.)      :    -0.01152010120276
+	DF-REMP Correlation Energy (a.u.)  :    -0.15463025473840
+	DF-REMP Total Energy (a.u.)        :   -75.78506806485001
+	======================================================================= 
+
+	======================================================================= 
+	================ DF-OREMP FINAL RESULTS =============================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	DF-HF Energy (a.u.)                :   -75.63187842179785
+	REF Energy (a.u.)                  :   -75.63115702739776
+	DF-OREMP Correlation Energy (a.u.) :    -0.15390886033835
+	Edforemp - Eref (a.u.)             :    -0.15463025473844
+	DF-OREMP Total Energy (a.u.)       :   -75.78578728213620
+	======================================================================= 
+
+
+*** tstop() called on south at Fri Dec  3 09:57:21 2021
+Module time:
+	user time   =      72.84 seconds =       1.21 minutes
+	system time =      28.24 seconds =       0.47 minutes
+	total time  =         28 seconds =       0.47 minutes
+Total time:
+	user time   =     436.27 seconds =       7.27 minutes
+	system time =     174.51 seconds =       2.91 minutes
+	total time  =        185 seconds =       3.08 minutes
+
+*** tstart() called on south
+*** at Fri Dec  3 09:57:21 2021
+
+	Forming Gamma^tilde...
+	Backtransforming OPDM, TPDM, and GFM to the AO basis...
+
+*** tstop() called on south at Fri Dec  3 09:57:21 2021
+Module time:
+	user time   =       0.75 seconds =       0.01 minutes
+	system time =       0.34 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =     437.02 seconds =       7.28 minutes
+	system time =     174.85 seconds =       2.91 minutes
+	total time  =        185 seconds =       3.08 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.046007417724
+       2        0.000000000000     0.040091039970    -0.023003708862
+       3        0.000000000000    -0.040091039970    -0.023003708862
+
+    DF-OREMP(1.00) Total Energy...........................................................PASSED
+    DF-OREMP(1.00) Analytic gradients.....................................................PASSED
+
+    Psi4 stopped on: Friday, 03 December 2021 09:57AM
+    Psi4 wall time for execution: 0:03:05.99
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dfremp-1/CMakeLists.txt
+++ b/tests/dfremp-1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dfremp-1 "psi;dfocc")

--- a/tests/dfremp-1/input.dat
+++ b/tests/dfremp-1/input.dat
@@ -1,0 +1,67 @@
+#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+
+test_dict = { "0.00": -188.31390691171310,  #TEST
+              "0.10": -188.31215742342371,  #TEST
+              "0.20": -188.31092314909370,  #TEST
+              "0.30": -188.31013985623537,  #TEST
+              "1.00": -188.31461864796250 } #TEST
+
+ESCF = -187.71389476084761
+
+molecule co2 {
+0 1
+C     0.1705487    0.3293777    0.0000000 
+O     1.2087051   -0.2081727    0.0000000 
+O    -0.8675996    0.8669312    0.0000000
+}
+
+
+
+set {
+  reference rhf
+  basis def2-TZVPP
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  freeze_core true
+  cc_type df
+  mp2_type df
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(1.00) Total Energy") #TEST
+

--- a/tests/dfremp-1/input.dat
+++ b/tests/dfremp-1/input.dat
@@ -1,4 +1,4 @@
-#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+#! density fitted REMP/cc-pVDZ energies for the CO2 molecule.
 
 test_dict = { "0.00": -188.31390691171310,  #TEST
               "0.10": -188.31215742342371,  #TEST
@@ -46,22 +46,22 @@ set{
 set remp_A=0.00
 e_remp=energy('remp')
 compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
-compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.00) Total Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.00) Total Energy") #TEST
 
 
 set remp_A=0.10
 e_remp=energy('remp')
-compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.10) Total Energy") #TEST
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.10) Total Energy") #TEST
 
 set remp_A=0.20
 e_remp=energy('remp')
-compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.20) Total Energy") #TEST
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.20) Total Energy") #TEST
 
 set remp_A=0.30
 e_remp=energy('remp')
-compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.30) Total Energy") #TEST
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.30) Total Energy") #TEST
 
 set remp_A=1.00
 e_remp=energy('remp')
-compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(1.00) Total Energy") #TEST
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(1.00) Total Energy") #TEST
 

--- a/tests/dfremp-1/output.ref
+++ b/tests/dfremp-1/output.ref
@@ -1,0 +1,2391 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 322c576 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 01 December 2021 04:09PM
+
+    Process ID: 20167
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+
+test_dict = { "0.00": -188.31390691171310,  #TEST
+              "0.10": -188.31215742342371,  #TEST
+              "0.20": -188.31092314909370,  #TEST
+              "0.30": -188.31013985623537,  #TEST
+              "1.00": -188.31461864796250 } #TEST
+
+ESCF = -187.71389476084761
+
+molecule co2 {
+0 1
+C     0.1705487    0.3293777    0.0000000 
+O     1.2087051   -0.2081727    0.0000000 
+O    -0.8675996    0.8669312    0.0000000
+}
+
+
+
+set {
+  reference rhf
+  basis def2-TZVPP
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-TZVPP-ri
+  freeze_core true
+  cc_type df
+  mp2_type df
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(1.00) Total Energy") #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 16:09:00 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 75
+    Number of basis functions: 229
+    Number of Cartesian functions: 275
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -186.80596774561187   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001365   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111168   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619394   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409835   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996938   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322575   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044683   -1.72211e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083471   -3.87871e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084633   -1.16245e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084744   -1.10845e-12   6.69960e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651940     2Ap   -20.651898     3Ap   -11.463777  
+       4Ap    -1.525562     5Ap    -1.472517     6Ap    -0.800765  
+       7Ap    -0.741285     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543648     2App   -0.543648  
+
+    Virtual:                                                              
+
+      10Ap     0.133024     3App    0.192244    11Ap     0.192244  
+      12Ap     0.261531     4App    0.302725    13Ap     0.302725  
+      14Ap     0.480474    15Ap     0.493111    16Ap     0.550202  
+       5App    0.579787    17Ap     0.579787     6App    0.756237  
+      18Ap     0.756237    19Ap     0.756262     7App    0.756262  
+      20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
+       8App    1.190775    23Ap     1.241868    24Ap     1.492249  
+      25Ap     1.547465     9App    1.571257    26Ap     1.571257  
+      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      11App    1.921537    29Ap     1.935006    12App    2.177028  
+      30Ap     2.177028    31Ap     2.293908    13App    2.293908  
+      32Ap     2.548589    33Ap     2.705561    14App    2.840798  
+      34Ap     2.840798    15App    3.092671    35Ap     3.092671  
+      16App    3.105806    36Ap     3.105806    37Ap     3.138648  
+      17App    3.138648    38Ap     3.212162    18App    3.212162  
+      39Ap     3.247329    40Ap     3.398428    41Ap     3.641545  
+      19App    3.700456    42Ap     3.700456    43Ap     3.976850  
+      20App    4.142075    44Ap     4.142075    45Ap     5.216739  
+      46Ap     5.282591    47Ap     5.505130    21App    5.505130  
+      48Ap     5.570680    22App    5.570680    49Ap     5.623988  
+      23App    5.623988    50Ap     6.226247    24App    6.226247  
+      51Ap     6.465162    25App    6.567601    52Ap     6.567601  
+      26App    6.781369    53Ap     6.781369    27App    6.782436  
+      54Ap     6.782436    28App    6.952168    55Ap     6.952168  
+      56Ap     7.197264    29App    7.197264    57Ap     7.354042  
+      58Ap     7.491053    30App    7.491053    59Ap     7.869240  
+      60Ap     7.983221    61Ap    24.927676    62Ap    45.424552  
+      63Ap    45.611682  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @DF-RHF Final Energy:  -187.71389476084744
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6693086840937212
+    Two-Electron Energy =                 126.0164204744440326
+    Total Energy =                       -187.7138947608474382
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 16:09:02 2021
+Module time:
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       0.89 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       0.89 seconds =       0.01 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   191 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 16:09:02 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+
+	Number of basis functions in the DF-CC basis: 228
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     12.95 MB 
+	Memory requirement for DF-CC int trans:     40.01 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     26.08 MB 
+	Memory requirement for Wabef term     :     30.88 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	DF-HF Energy (a.u.)                :  -187.71389476084744
+	REF Energy (a.u.)                  :  -187.71389476084744
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796228
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5833797097          0.0173441774         6.00e-05  
+   2      -0.5962601298         -0.0128804201         1.77e-05  
+   3      -0.5998347003         -0.0035745705         8.75e-06  
+   4      -0.5999095392         -0.0000748388         2.78e-06  
+   5      -0.5999975407         -0.0000880015         6.64e-07  
+   6      -0.6000144843         -0.0000169436         2.11e-07  
+   7      -0.6000127397          0.0000017446         6.75e-08  
+   8      -0.6000130283         -0.0000002886         8.61e-09  
+   9      -0.6000124230          0.0000006052         1.17e-08  
+  10      -0.6000122622          0.0000001608         2.92e-09  
+  11      -0.6000121932          0.0000000690         7.71e-10  
+  12      -0.6000121620          0.0000000312         2.25e-10  
+  13      -0.6000121526          0.0000000094         8.52e-11  
+  14      -0.6000121508          0.0000000018         3.82e-11  
+  15      -0.6000121509         -0.0000000000         5.28e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71389476084744
+	REF Energy (a.u.)                  :  -187.71389476084744
+	DF-REMP Correlation Energy (a.u.)  :    -0.60001215086551
+	DF-REMP Total Energy (a.u.)        :  -188.31390691171293
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 16:09:28 2021
+Module time:
+	user time   =      61.84 seconds =       1.03 minutes
+	system time =      22.33 seconds =       0.37 minutes
+	total time  =         26 seconds =       0.43 minutes
+Total time:
+	user time   =      64.57 seconds =       1.08 minutes
+	system time =      23.39 seconds =       0.39 minutes
+	total time  =         28 seconds =       0.47 minutes
+    DF-SCF Energy.........................................................................PASSED
+    REMP(0.00) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 16:09:28 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 75
+    Number of basis functions: 229
+    Number of Cartesian functions: 275
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -186.80596774561181   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001365   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111162   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619394   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409830   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996964   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322561   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044683   -1.72212e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083488   -3.88042e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084650   -1.16245e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084741   -9.09495e-13   6.69961e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651940     2Ap   -20.651898     3Ap   -11.463777  
+       4Ap    -1.525562     5Ap    -1.472517     6Ap    -0.800765  
+       7Ap    -0.741285     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543648     2App   -0.543648  
+
+    Virtual:                                                              
+
+      10Ap     0.133024     3App    0.192244    11Ap     0.192244  
+      12Ap     0.261531     4App    0.302725    13Ap     0.302725  
+      14Ap     0.480474    15Ap     0.493111    16Ap     0.550202  
+       5App    0.579787    17Ap     0.579787     6App    0.756237  
+      18Ap     0.756237    19Ap     0.756262     7App    0.756262  
+      20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
+       8App    1.190775    23Ap     1.241868    24Ap     1.492249  
+      25Ap     1.547465     9App    1.571257    26Ap     1.571257  
+      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      11App    1.921537    29Ap     1.935006    12App    2.177028  
+      30Ap     2.177028    31Ap     2.293908    13App    2.293908  
+      32Ap     2.548589    33Ap     2.705561    14App    2.840798  
+      34Ap     2.840798    15App    3.092671    35Ap     3.092671  
+      16App    3.105806    36Ap     3.105806    37Ap     3.138648  
+      17App    3.138648    38Ap     3.212162    18App    3.212162  
+      39Ap     3.247329    40Ap     3.398428    41Ap     3.641545  
+      19App    3.700456    42Ap     3.700456    43Ap     3.976850  
+      20App    4.142075    44Ap     4.142075    45Ap     5.216739  
+      46Ap     5.282591    47Ap     5.505130    21App    5.505130  
+      48Ap     5.570680    22App    5.570680    49Ap     5.623988  
+      23App    5.623988    50Ap     6.226247    24App    6.226247  
+      51Ap     6.465162    25App    6.567601    52Ap     6.567601  
+      26App    6.781369    53Ap     6.781369    27App    6.782436  
+      54Ap     6.782436    28App    6.952168    55Ap     6.952168  
+      56Ap     7.197264    29App    7.197264    57Ap     7.354042  
+      58Ap     7.491053    30App    7.491053    59Ap     7.869240  
+      60Ap     7.983221    61Ap    24.927676    62Ap    45.424552  
+      63Ap    45.611682  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @DF-RHF Final Energy:  -187.71389476084741
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6693086840940055
+    Two-Electron Energy =                 126.0164204744443452
+    Total Energy =                       -187.7138947608474098
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 16:09:30 2021
+Module time:
+	user time   =       4.25 seconds =       0.07 minutes
+	system time =       1.36 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =      68.85 seconds =       1.15 minutes
+	system time =      24.77 seconds =       0.41 minutes
+	total time  =         30 seconds =       0.50 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   191 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 16:09:30 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+
+	Number of basis functions in the DF-CC basis: 228
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     12.95 MB 
+	Memory requirement for DF-CC int trans:     40.01 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     26.08 MB 
+	Memory requirement for Wabef term     :     30.88 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	DF-HF Energy (a.u.)                :  -187.71389476084741
+	REF Energy (a.u.)                  :  -187.71389476084741
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796225
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5851141275          0.0156097596         4.17e-05  
+   2      -0.5958030003         -0.0106888728         1.44e-05  
+   3      -0.5981899836         -0.0023869833         4.14e-06  
+   4      -0.5982113573         -0.0000213737         1.10e-06  
+   5      -0.5982564141         -0.0000450568         1.51e-07  
+   6      -0.5982636951         -0.0000072809         5.31e-08  
+   7      -0.5982629452          0.0000007499         1.62e-08  
+   8      -0.5982629266          0.0000000186         3.12e-09  
+   9      -0.5982627286          0.0000001980         3.45e-09  
+  10      -0.5982626860          0.0000000426         7.67e-10  
+  11      -0.5982626705          0.0000000155         1.89e-10  
+  12      -0.5982626643          0.0000000063         5.57e-11  
+  13      -0.5982626628          0.0000000015         2.12e-11  
+  14      -0.5982626626          0.0000000002         6.53e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71389476084741
+	REF Energy (a.u.)                  :  -187.71389476084741
+	DF-REMP Correlation Energy (a.u.)  :    -0.59826266257628
+	DF-REMP Total Energy (a.u.)        :  -188.31215742342368
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 16:10:01 2021
+Module time:
+	user time   =      62.42 seconds =       1.04 minutes
+	system time =      25.28 seconds =       0.42 minutes
+	total time  =         31 seconds =       0.52 minutes
+Total time:
+	user time   =     131.69 seconds =       2.19 minutes
+	system time =      50.23 seconds =       0.84 minutes
+	total time  =         61 seconds =       1.02 minutes
+    REMP(0.10) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:01 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 75
+    Number of basis functions: 229
+    Number of Cartesian functions: 275
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -186.80596774561181   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001345   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111154   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619368   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409844   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996932   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322558   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044715   -1.72216e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083473   -3.87587e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084647   -1.17382e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084755   -1.08002e-12   6.69961e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651940     2Ap   -20.651898     3Ap   -11.463777  
+       4Ap    -1.525562     5Ap    -1.472517     6Ap    -0.800765  
+       7Ap    -0.741285     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543648     2App   -0.543648  
+
+    Virtual:                                                              
+
+      10Ap     0.133024     3App    0.192244    11Ap     0.192244  
+      12Ap     0.261531     4App    0.302725    13Ap     0.302725  
+      14Ap     0.480474    15Ap     0.493111    16Ap     0.550202  
+       5App    0.579787    17Ap     0.579787     6App    0.756237  
+      18Ap     0.756237    19Ap     0.756262     7App    0.756262  
+      20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
+       8App    1.190775    23Ap     1.241868    24Ap     1.492249  
+      25Ap     1.547465     9App    1.571257    26Ap     1.571257  
+      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      11App    1.921537    29Ap     1.935006    12App    2.177028  
+      30Ap     2.177028    31Ap     2.293908    13App    2.293908  
+      32Ap     2.548589    33Ap     2.705561    14App    2.840798  
+      34Ap     2.840798    15App    3.092671    35Ap     3.092671  
+      16App    3.105806    36Ap     3.105806    37Ap     3.138648  
+      17App    3.138648    38Ap     3.212162    18App    3.212162  
+      39Ap     3.247329    40Ap     3.398428    41Ap     3.641545  
+      19App    3.700456    42Ap     3.700456    43Ap     3.976850  
+      20App    4.142075    44Ap     4.142075    45Ap     5.216739  
+      46Ap     5.282591    47Ap     5.505130    21App    5.505130  
+      48Ap     5.570680    22App    5.570680    49Ap     5.623988  
+      23App    5.623988    50Ap     6.226247    24App    6.226247  
+      51Ap     6.465162    25App    6.567601    52Ap     6.567601  
+      26App    6.781369    53Ap     6.781369    27App    6.782436  
+      54Ap     6.782436    28App    6.952168    55Ap     6.952168  
+      56Ap     7.197264    29App    7.197264    57Ap     7.354042  
+      58Ap     7.491053    30App    7.491053    59Ap     7.869240  
+      60Ap     7.983221    61Ap    24.927676    62Ap    45.424552  
+      63Ap    45.611682  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @DF-RHF Final Energy:  -187.71389476084755
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6693086840944034
+    Two-Electron Energy =                 126.0164204744446010
+    Total Energy =                       -187.7138947608475519
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 16:10:03 2021
+Module time:
+	user time   =       3.10 seconds =       0.05 minutes
+	system time =       1.32 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     134.82 seconds =       2.25 minutes
+	system time =      51.56 seconds =       0.86 minutes
+	total time  =         63 seconds =       1.05 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   191 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:04 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+
+	Number of basis functions in the DF-CC basis: 228
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     12.95 MB 
+	Memory requirement for DF-CC int trans:     40.01 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     26.08 MB 
+	Memory requirement for Wabef term     :     30.88 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	DF-HF Energy (a.u.)                :  -187.71389476084755
+	REF Energy (a.u.)                  :  -187.71389476084755
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796239
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5868485452          0.0138753419         5.62e-05  
+   2      -0.5954836736         -0.0086351284         1.36e-05  
+   3      -0.5970024550         -0.0015187814         4.44e-06  
+   4      -0.5970034785         -0.0000010235         3.37e-07  
+   5      -0.5970258248         -0.0000223463         1.11e-07  
+   6      -0.5970288014         -0.0000029766         4.27e-08  
+   7      -0.5970285013          0.0000003001         1.00e-08  
+   8      -0.5970284604          0.0000000409         2.52e-09  
+   9      -0.5970284028          0.0000000576         9.33e-10  
+  10      -0.5970283927          0.0000000101         1.38e-10  
+  11      -0.5970283896          0.0000000031         3.00e-11  
+  12      -0.5970283885          0.0000000011         9.42e-12  
+  13      -0.5970283882          0.0000000002         2.92e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71389476084755
+	REF Energy (a.u.)                  :  -187.71389476084755
+	DF-REMP Correlation Energy (a.u.)  :    -0.59702838824625
+	DF-REMP Total Energy (a.u.)        :  -188.31092314909381
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 16:10:31 2021
+Module time:
+	user time   =      54.91 seconds =       0.92 minutes
+	system time =      21.67 seconds =       0.36 minutes
+	total time  =         27 seconds =       0.45 minutes
+Total time:
+	user time   =     190.07 seconds =       3.17 minutes
+	system time =      73.39 seconds =       1.22 minutes
+	total time  =         91 seconds =       1.52 minutes
+    REMP(0.20) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:31 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 75
+    Number of basis functions: 229
+    Number of Cartesian functions: 275
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -186.80596774561192   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001371   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111151   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619380   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409818   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996907   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322561   -6.23257e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044709   -1.72215e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083465   -3.87558e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084644   -1.17950e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084761   -1.16529e-12   6.69961e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651940     2Ap   -20.651898     3Ap   -11.463777  
+       4Ap    -1.525562     5Ap    -1.472517     6Ap    -0.800765  
+       7Ap    -0.741285     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543648     2App   -0.543648  
+
+    Virtual:                                                              
+
+      10Ap     0.133024     3App    0.192244    11Ap     0.192244  
+      12Ap     0.261531     4App    0.302725    13Ap     0.302725  
+      14Ap     0.480474    15Ap     0.493111    16Ap     0.550202  
+       5App    0.579787    17Ap     0.579787     6App    0.756237  
+      18Ap     0.756237    19Ap     0.756262     7App    0.756262  
+      20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
+       8App    1.190775    23Ap     1.241868    24Ap     1.492249  
+      25Ap     1.547465     9App    1.571257    26Ap     1.571257  
+      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      11App    1.921537    29Ap     1.935006    12App    2.177028  
+      30Ap     2.177028    31Ap     2.293908    13App    2.293908  
+      32Ap     2.548589    33Ap     2.705561    14App    2.840798  
+      34Ap     2.840798    15App    3.092671    35Ap     3.092671  
+      16App    3.105806    36Ap     3.105806    37Ap     3.138648  
+      17App    3.138648    38Ap     3.212162    18App    3.212162  
+      39Ap     3.247329    40Ap     3.398428    41Ap     3.641545  
+      19App    3.700456    42Ap     3.700456    43Ap     3.976850  
+      20App    4.142075    44Ap     4.142075    45Ap     5.216739  
+      46Ap     5.282591    47Ap     5.505130    21App    5.505130  
+      48Ap     5.570680    22App    5.570680    49Ap     5.623988  
+      23App    5.623988    50Ap     6.226247    24App    6.226247  
+      51Ap     6.465162    25App    6.567601    52Ap     6.567601  
+      26App    6.781369    53Ap     6.781369    27App    6.782436  
+      54Ap     6.782436    28App    6.952168    55Ap     6.952168  
+      56Ap     7.197264    29App    7.197264    57Ap     7.354042  
+      58Ap     7.491053    30App    7.491053    59Ap     7.869240  
+      60Ap     7.983221    61Ap    24.927676    62Ap    45.424552  
+      63Ap    45.611682  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @DF-RHF Final Energy:  -187.71389476084761
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6693086840940623
+    Two-Electron Energy =                 126.0164204744442031
+    Total Energy =                       -187.7138947608476087
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 16:10:32 2021
+Module time:
+	user time   =       2.35 seconds =       0.04 minutes
+	system time =       1.06 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     192.45 seconds =       3.21 minutes
+	system time =      74.46 seconds =       1.24 minutes
+	total time  =         92 seconds =       1.53 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   191 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:33 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+
+	Number of basis functions in the DF-CC basis: 228
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     12.95 MB 
+	Memory requirement for DF-CC int trans:     40.01 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     26.08 MB 
+	Memory requirement for Wabef term     :     30.88 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	DF-HF Energy (a.u.)                :  -187.71389476084761
+	REF Energy (a.u.)                  :  -187.71389476084761
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796245
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.5885829629          0.0121409242         5.30e-05  
+   2      -0.5953280276         -0.0067450646         1.04e-05  
+   3      -0.5962379762         -0.0009099487         3.02e-06  
+   4      -0.5962336273          0.0000043489         5.63e-07  
+   5      -0.5962441174         -0.0000104900         8.08e-08  
+   6      -0.5962452429         -0.0000011256         1.53e-08  
+   7      -0.5962451337          0.0000001093         2.63e-09  
+   8      -0.5962451126          0.0000000211         9.49e-10  
+   9      -0.5962450980          0.0000000146         1.52e-10  
+  10      -0.5962450959          0.0000000021         2.59e-11  
+  11      -0.5962450954          0.0000000005         6.41e-12  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71389476084761
+	REF Energy (a.u.)                  :  -187.71389476084761
+	DF-REMP Correlation Energy (a.u.)  :    -0.59624509538799
+	DF-REMP Total Energy (a.u.)        :  -188.31013985623559
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 16:10:52 2021
+Module time:
+	user time   =      44.09 seconds =       0.73 minutes
+	system time =      15.27 seconds =       0.25 minutes
+	total time  =         19 seconds =       0.32 minutes
+Total time:
+	user time   =     236.89 seconds =       3.95 minutes
+	system time =      89.81 seconds =       1.50 minutes
+	total time  =        112 seconds =       1.87 minutes
+    REMP(0.30) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:52 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line   133 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+    atoms 2-3 entry O          line   199 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: cs
+    Full point group: C_inf_v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C           -0.000002355182     0.000000000000    -0.000002097103    12.000000000000
+         O           -0.000002355182     0.000000000000     1.169069818307    15.994914619570
+         O            0.000004122130     0.000000000000    -1.169068244980    15.994914619570
+
+  Running in cs symmetry.
+
+  Rotational constants: A = ************  B =      0.38557  C =      0.38557 [cm^-1]
+  Rotational constants: A = ************  B =  11559.12512  C =  11559.12512 [MHz]
+  Nuclear repulsion =   57.938993448802243
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 22
+  Nalpha       = 11
+  Nbeta        = 11
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-TZVPP
+    Blend: DEF2-TZVPP
+    Number of shells: 33
+    Number of basis functions: 93
+    Number of Cartesian functions: 108
+    Spherical Harmonics?: true
+    Max angular momentum: 3
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 75
+    Number of basis functions: 229
+    Number of Cartesian functions: 275
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 5.0295108035E-04.
+  Reciprocal condition number of the overlap matrix is 9.3859750461E-05.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A'        63      63 
+     A"        30      30 
+   -------------------------
+    Total      93      93
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-RHF iter SAD:  -186.80596774561192   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001337   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111168   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619380   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409841   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996941   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322592   -6.23257e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044692   -1.72210e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083471   -3.87786e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084627   -1.15676e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084752   -1.25056e-12   6.69961e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1Ap   -20.651940     2Ap   -20.651898     3Ap   -11.463777  
+       4Ap    -1.525562     5Ap    -1.472517     6Ap    -0.800765  
+       7Ap    -0.741285     8Ap    -0.711598     1App   -0.711598  
+       9Ap    -0.543648     2App   -0.543648  
+
+    Virtual:                                                              
+
+      10Ap     0.133024     3App    0.192244    11Ap     0.192244  
+      12Ap     0.261531     4App    0.302725    13Ap     0.302725  
+      14Ap     0.480474    15Ap     0.493111    16Ap     0.550202  
+       5App    0.579787    17Ap     0.579787     6App    0.756237  
+      18Ap     0.756237    19Ap     0.756262     7App    0.756262  
+      20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
+       8App    1.190775    23Ap     1.241868    24Ap     1.492249  
+      25Ap     1.547465     9App    1.571257    26Ap     1.571257  
+      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      11App    1.921537    29Ap     1.935006    12App    2.177028  
+      30Ap     2.177028    31Ap     2.293908    13App    2.293908  
+      32Ap     2.548589    33Ap     2.705561    14App    2.840798  
+      34Ap     2.840798    15App    3.092671    35Ap     3.092671  
+      16App    3.105806    36Ap     3.105806    37Ap     3.138648  
+      17App    3.138648    38Ap     3.212162    18App    3.212162  
+      39Ap     3.247329    40Ap     3.398428    41Ap     3.641545  
+      19App    3.700456    42Ap     3.700456    43Ap     3.976850  
+      20App    4.142075    44Ap     4.142075    45Ap     5.216739  
+      46Ap     5.282591    47Ap     5.505130    21App    5.505130  
+      48Ap     5.570680    22App    5.570680    49Ap     5.623988  
+      23App    5.623988    50Ap     6.226247    24App    6.226247  
+      51Ap     6.465162    25App    6.567601    52Ap     6.567601  
+      26App    6.781369    53Ap     6.781369    27App    6.782436  
+      54Ap     6.782436    28App    6.952168    55Ap     6.952168  
+      56Ap     7.197264    29App    7.197264    57Ap     7.354042  
+      58Ap     7.491053    30App    7.491053    59Ap     7.869240  
+      60Ap     7.983221    61Ap    24.927676    62Ap    45.424552  
+      63Ap    45.611682  
+
+    Final Occupation by Irrep:
+             Ap   App 
+    DOCC [     9,    2 ]
+
+  @DF-RHF Final Energy:  -187.71389476084752
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =             57.9389934488022433
+    One-Electron Energy =                -371.6693086840940055
+    Two-Electron Energy =                 126.0164204744442316
+    Total Energy =                       -187.7138947608475235
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 16:10:53 2021
+Module time:
+	user time   =       3.79 seconds =       0.06 minutes
+	system time =       1.33 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     240.71 seconds =       4.01 minutes
+	system time =      91.17 seconds =       1.52 minutes
+	total time  =        113 seconds =       1.88 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-3 entry O          line   318 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-TZVPP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   191 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+    atoms 2-3 entry O          line   285 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-tzvpp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 16:10:54 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-TZVPP-RI   !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   OCC   VIR   FV 
+	----------------------
+	  3    8    82    0
+
+	Number of basis functions in the DF-CC basis: 228
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :     12.95 MB 
+	Memory requirement for DF-CC int trans:     40.01 MB 
+	Memory requirement for CC contractions:     13.13 MB 
+	Total memory requirement for DF+CC int:     26.08 MB 
+	Memory requirement for Wabef term     :     30.88 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	DF-HF Energy (a.u.)                :  -187.71389476084752
+	REF Energy (a.u.)                  :  -187.71389476084752
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796236
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.6007238871          0.0000000000         3.00e-20  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
+	SCF Energy (a.u.)                  :  -187.71389476084752
+	REF Energy (a.u.)                  :  -187.71389476084752
+	DF-REMP Correlation Energy (a.u.)  :    -0.60072388711485
+	DF-REMP Total Energy (a.u.)        :  -188.31461864796236
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 16:10:56 2021
+Module time:
+	user time   =       4.94 seconds =       0.08 minutes
+	system time =       1.86 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =     246.06 seconds =       4.10 minutes
+	system time =      93.22 seconds =       1.55 minutes
+	total time  =        116 seconds =       1.93 minutes
+    REMP(1.00) Total Energy...............................................................PASSED
+
+    Psi4 stopped on: Wednesday, 01 December 2021 04:10PM
+    Psi4 wall time for execution: 0:01:55.31
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dfremp-1/output.ref
+++ b/tests/dfremp-1/output.ref
@@ -3,7 +3,7 @@
           Psi4: An Open-Source Ab Initio Electronic Structure Package
                                Psi4 undefined 
 
-                         Git: Rev {changes_for_global_merge} 322c576 dirty
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
 
 
     D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
@@ -30,9 +30,9 @@
     -----------------------------------------------------------------------
 
 
-    Psi4 started on: Wednesday, 01 December 2021 04:09PM
+    Psi4 started on: Wednesday, 01 December 2021 07:14PM
 
-    Process ID: 20167
+    Process ID: 26034
     Host:       south
     PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
     Memory:     500.0 MiB
@@ -41,7 +41,7 @@
   ==> Input File <==
 
 --------------------------------------------------------------------------
-#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+#! density fitted REMP/cc-pVDZ energies for the CO2 molecule.
 
 test_dict = { "0.00": -188.31390691171310,  #TEST
               "0.10": -188.31215742342371,  #TEST
@@ -89,24 +89,24 @@ set{
 set remp_A=0.00
 e_remp=energy('remp')
 compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
-compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.00) Total Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.00) Total Energy") #TEST
 
 
 set remp_A=0.10
 e_remp=energy('remp')
-compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.10) Total Energy") #TEST
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.10) Total Energy") #TEST
 
 set remp_A=0.20
 e_remp=energy('remp')
-compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.20) Total Energy") #TEST
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.20) Total Energy") #TEST
 
 set remp_A=0.30
 e_remp=energy('remp')
-compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "REMP(0.30) Total Energy") #TEST
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.30) Total Energy") #TEST
 
 set remp_A=1.00
 e_remp=energy('remp')
-compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "REMP(1.00) Total Energy") #TEST
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(1.00) Total Energy") #TEST
 
 --------------------------------------------------------------------------
 
@@ -114,7 +114,7 @@ Scratch directory: /scr/behnle/
     For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
 
 *** tstart() called on south
-*** at Wed Dec  1 16:09:00 2021
+*** at Wed Dec  1 19:14:37 2021
 
    => Loading Basis Set <=
 
@@ -233,17 +233,17 @@ Scratch directory: /scr/behnle/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -186.80596774561187   -1.86806e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.62701476001365   -8.21047e-01   7.28763e-03 DIIS
-   @DF-RHF iter   2:  -187.66737543111168   -4.03607e-02   5.43583e-03 DIIS
-   @DF-RHF iter   3:  -187.71367769619394   -4.63023e-02   2.57307e-04 DIIS
-   @DF-RHF iter   4:  -187.71388356409835   -2.05868e-04   5.64652e-05 DIIS
-   @DF-RHF iter   5:  -187.71389411996938   -1.05559e-05   1.18721e-05 DIIS
-   @DF-RHF iter   6:  -187.71389474322575   -6.23256e-07   1.81898e-06 DIIS
-   @DF-RHF iter   7:  -187.71389476044683   -1.72211e-08   3.17692e-07 DIIS
-   @DF-RHF iter   8:  -187.71389476083471   -3.87871e-10   7.35240e-08 DIIS
-   @DF-RHF iter   9:  -187.71389476084633   -1.16245e-11   2.52664e-08 DIIS
-   @DF-RHF iter  10:  -187.71389476084744   -1.10845e-12   6.69960e-09 DIIS
+   @DF-RHF iter SAD:  -186.80596774561184   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001359   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111151   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619397   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409838   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996950   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322598   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044715   -1.72212e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083479   -3.87644e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084656   -1.17666e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084747   -9.09495e-13   6.69961e-09 DIIS
   Energy and wave function converged.
 
 
@@ -294,14 +294,14 @@ Scratch directory: /scr/behnle/
              Ap   App 
     DOCC [     9,    2 ]
 
-  @DF-RHF Final Energy:  -187.71389476084744
+  @DF-RHF Final Energy:  -187.71389476084747
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             57.9389934488022433
-    One-Electron Energy =                -371.6693086840937212
-    Two-Electron Energy =                 126.0164204744440326
-    Total Energy =                       -187.7138947608474382
+    One-Electron Energy =                -371.6693086840939486
+    Two-Electron Energy =                 126.0164204744442316
+    Total Energy =                       -187.7138947608474666
 
 Computation Completed
 
@@ -323,15 +323,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
 
 
-*** tstop() called on south at Wed Dec  1 16:09:02 2021
+*** tstop() called on south at Wed Dec  1 19:14:38 2021
 Module time:
-	user time   =       2.29 seconds =       0.04 minutes
-	system time =       0.89 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.83 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =       2.29 seconds =       0.04 minutes
-	system time =       0.89 seconds =       0.01 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       2.15 seconds =       0.04 minutes
+	system time =       0.83 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -355,7 +355,7 @@ Total time:
 
 
 *** tstart() called on south
-*** at Wed Dec  1 16:09:02 2021
+*** at Wed Dec  1 19:14:38 2021
 
 
 
@@ -514,10 +514,10 @@ Total time:
 	Computing DF-MP2 energy ... 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	DF-HF Energy (a.u.)                :  -187.71389476084744
-	REF Energy (a.u.)                  :  -187.71389476084744
+	DF-HF Energy (a.u.)                :  -187.71389476084747
+	REF Energy (a.u.)                  :  -187.71389476084747
 	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
-	DF-MP2 Total Energy (a.u.)         :  -188.31461864796228
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796231
 	======================================================================= 
 	Using A=        0 as REMP mixing parameter
 
@@ -527,21 +527,21 @@ Total time:
 
   Iter       E_corr                  DE                 T2 RMS      
   ----   ----------------      ----------------       ----------    
-   1      -0.5833797097          0.0173441774         6.00e-05  
-   2      -0.5962601298         -0.0128804201         1.77e-05  
-   3      -0.5998347003         -0.0035745705         8.75e-06  
-   4      -0.5999095392         -0.0000748388         2.78e-06  
-   5      -0.5999975407         -0.0000880015         6.64e-07  
-   6      -0.6000144843         -0.0000169436         2.11e-07  
-   7      -0.6000127397          0.0000017446         6.75e-08  
+   1      -0.5833797097          0.0173441774         7.03e-05  
+   2      -0.5962601298         -0.0128804201         2.46e-05  
+   3      -0.5998347003         -0.0035745705         5.71e-06  
+   4      -0.5999095392         -0.0000748388         1.78e-06  
+   5      -0.5999975407         -0.0000880015         7.35e-07  
+   6      -0.6000144843         -0.0000169436         1.79e-07  
+   7      -0.6000127397          0.0000017446         6.34e-08  
    8      -0.6000130283         -0.0000002886         8.61e-09  
-   9      -0.6000124230          0.0000006052         1.17e-08  
-  10      -0.6000122622          0.0000001608         2.92e-09  
-  11      -0.6000121932          0.0000000690         7.71e-10  
+   9      -0.6000124230          0.0000006052         7.33e-09  
+  10      -0.6000122622          0.0000001608         2.05e-09  
+  11      -0.6000121932          0.0000000690         6.02e-10  
   12      -0.6000121620          0.0000000312         2.25e-10  
-  13      -0.6000121526          0.0000000094         8.52e-11  
-  14      -0.6000121508          0.0000000018         3.82e-11  
-  15      -0.6000121509         -0.0000000000         5.28e-12  
+  13      -0.6000121526          0.0000000094         7.02e-11  
+  14      -0.6000121508          0.0000000018         6.21e-12  
+  15      -0.6000121509         -0.0000000000         9.35e-12  
 
  ============================================================================== 
  ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
@@ -551,30 +551,30 @@ Total time:
 	================ REMP FINAL RESULTS =================================== 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	SCF Energy (a.u.)                  :  -187.71389476084744
-	REF Energy (a.u.)                  :  -187.71389476084744
+	SCF Energy (a.u.)                  :  -187.71389476084747
+	REF Energy (a.u.)                  :  -187.71389476084747
 	DF-REMP Correlation Energy (a.u.)  :    -0.60001215086551
-	DF-REMP Total Energy (a.u.)        :  -188.31390691171293
+	DF-REMP Total Energy (a.u.)        :  -188.31390691171296
 	======================================================================= 
 
 
-*** tstop() called on south at Wed Dec  1 16:09:28 2021
+*** tstop() called on south at Wed Dec  1 19:14:58 2021
 Module time:
-	user time   =      61.84 seconds =       1.03 minutes
-	system time =      22.33 seconds =       0.37 minutes
-	total time  =         26 seconds =       0.43 minutes
+	user time   =      53.43 seconds =       0.89 minutes
+	system time =      14.81 seconds =       0.25 minutes
+	total time  =         20 seconds =       0.33 minutes
 Total time:
-	user time   =      64.57 seconds =       1.08 minutes
-	system time =      23.39 seconds =       0.39 minutes
-	total time  =         28 seconds =       0.47 minutes
+	user time   =      56.06 seconds =       0.93 minutes
+	system time =      15.79 seconds =       0.26 minutes
+	total time  =         21 seconds =       0.35 minutes
     DF-SCF Energy.........................................................................PASSED
-    REMP(0.00) Total Energy...............................................................PASSED
+    DF-REMP(0.00) Total Energy............................................................PASSED
 
 Scratch directory: /scr/behnle/
     For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
 
 *** tstart() called on south
-*** at Wed Dec  1 16:09:28 2021
+*** at Wed Dec  1 19:14:58 2021
 
    => Loading Basis Set <=
 
@@ -693,17 +693,17 @@ Scratch directory: /scr/behnle/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -186.80596774561181   -1.86806e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.62701476001365   -8.21047e-01   7.28763e-03 DIIS
-   @DF-RHF iter   2:  -187.66737543111162   -4.03607e-02   5.43583e-03 DIIS
-   @DF-RHF iter   3:  -187.71367769619394   -4.63023e-02   2.57307e-04 DIIS
-   @DF-RHF iter   4:  -187.71388356409830   -2.05868e-04   5.64652e-05 DIIS
-   @DF-RHF iter   5:  -187.71389411996964   -1.05559e-05   1.18721e-05 DIIS
-   @DF-RHF iter   6:  -187.71389474322561   -6.23256e-07   1.81898e-06 DIIS
-   @DF-RHF iter   7:  -187.71389476044683   -1.72212e-08   3.17692e-07 DIIS
-   @DF-RHF iter   8:  -187.71389476083488   -3.88042e-10   7.35240e-08 DIIS
-   @DF-RHF iter   9:  -187.71389476084650   -1.16245e-11   2.52664e-08 DIIS
-   @DF-RHF iter  10:  -187.71389476084741   -9.09495e-13   6.69961e-09 DIIS
+   @DF-RHF iter SAD:  -186.80596774561187   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001362   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111168   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619397   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409832   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996941   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322558   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044706   -1.72215e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083482   -3.87757e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084647   -1.16529e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084738   -9.09495e-13   6.69960e-09 DIIS
   Energy and wave function converged.
 
 
@@ -754,14 +754,14 @@ Scratch directory: /scr/behnle/
              Ap   App 
     DOCC [     9,    2 ]
 
-  @DF-RHF Final Energy:  -187.71389476084741
+  @DF-RHF Final Energy:  -187.71389476084738
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             57.9389934488022433
-    One-Electron Energy =                -371.6693086840940055
-    Two-Electron Energy =                 126.0164204744443452
-    Total Energy =                       -187.7138947608474098
+    One-Electron Energy =                -371.6693086840937781
+    Two-Electron Energy =                 126.0164204744441463
+    Total Energy =                       -187.7138947608473813
 
 Computation Completed
 
@@ -783,15 +783,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
 
 
-*** tstop() called on south at Wed Dec  1 16:09:30 2021
+*** tstop() called on south at Wed Dec  1 19:14:59 2021
 Module time:
-	user time   =       4.25 seconds =       0.07 minutes
-	system time =       1.36 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       4.19 seconds =       0.07 minutes
+	system time =       1.34 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =      68.85 seconds =       1.15 minutes
-	system time =      24.77 seconds =       0.41 minutes
-	total time  =         30 seconds =       0.50 minutes
+	user time   =      60.28 seconds =       1.00 minutes
+	system time =      17.16 seconds =       0.29 minutes
+	total time  =         22 seconds =       0.37 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -815,7 +815,7 @@ Total time:
 
 
 *** tstart() called on south
-*** at Wed Dec  1 16:09:30 2021
+*** at Wed Dec  1 19:15:00 2021
 
 
 
@@ -974,10 +974,10 @@ Total time:
 	Computing DF-MP2 energy ... 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	DF-HF Energy (a.u.)                :  -187.71389476084741
-	REF Energy (a.u.)                  :  -187.71389476084741
-	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
-	DF-MP2 Total Energy (a.u.)         :  -188.31461864796225
+	DF-HF Energy (a.u.)                :  -187.71389476084738
+	REF Energy (a.u.)                  :  -187.71389476084738
+	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711484
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796222
 	======================================================================= 
 	Using A=      0.1 as REMP mixing parameter
 
@@ -987,20 +987,20 @@ Total time:
 
   Iter       E_corr                  DE                 T2 RMS      
   ----   ----------------      ----------------       ----------    
-   1      -0.5851141275          0.0156097596         4.17e-05  
-   2      -0.5958030003         -0.0106888728         1.44e-05  
-   3      -0.5981899836         -0.0023869833         4.14e-06  
-   4      -0.5982113573         -0.0000213737         1.10e-06  
-   5      -0.5982564141         -0.0000450568         1.51e-07  
-   6      -0.5982636951         -0.0000072809         5.31e-08  
-   7      -0.5982629452          0.0000007499         1.62e-08  
-   8      -0.5982629266          0.0000000186         3.12e-09  
-   9      -0.5982627286          0.0000001980         3.45e-09  
-  10      -0.5982626860          0.0000000426         7.67e-10  
-  11      -0.5982626705          0.0000000155         1.89e-10  
-  12      -0.5982626643          0.0000000063         5.57e-11  
-  13      -0.5982626628          0.0000000015         2.12e-11  
-  14      -0.5982626626          0.0000000002         6.53e-12  
+   1      -0.5851141275          0.0156097596         4.89e-05  
+   2      -0.5958030003         -0.0106888728         1.24e-05  
+   3      -0.5981899836         -0.0023869833         5.93e-06  
+   4      -0.5982113573         -0.0000213737         9.38e-07  
+   5      -0.5982564141         -0.0000450568         2.10e-07  
+   6      -0.5982636951         -0.0000072809         3.25e-08  
+   7      -0.5982629452          0.0000007499         2.55e-08  
+   8      -0.5982629266          0.0000000186         7.49e-09  
+   9      -0.5982627286          0.0000001980         3.33e-09  
+  10      -0.5982626860          0.0000000426         4.25e-10  
+  11      -0.5982626705          0.0000000155         1.77e-10  
+  12      -0.5982626643          0.0000000063         2.74e-11  
+  13      -0.5982626628          0.0000000015         1.32e-11  
+  14      -0.5982626626          0.0000000002         3.61e-12  
 
  ============================================================================== 
  ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
@@ -1010,29 +1010,29 @@ Total time:
 	================ REMP FINAL RESULTS =================================== 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	SCF Energy (a.u.)                  :  -187.71389476084741
-	REF Energy (a.u.)                  :  -187.71389476084741
+	SCF Energy (a.u.)                  :  -187.71389476084738
+	REF Energy (a.u.)                  :  -187.71389476084738
 	DF-REMP Correlation Energy (a.u.)  :    -0.59826266257628
-	DF-REMP Total Energy (a.u.)        :  -188.31215742342368
+	DF-REMP Total Energy (a.u.)        :  -188.31215742342366
 	======================================================================= 
 
 
-*** tstop() called on south at Wed Dec  1 16:10:01 2021
+*** tstop() called on south at Wed Dec  1 19:15:17 2021
 Module time:
-	user time   =      62.42 seconds =       1.04 minutes
-	system time =      25.28 seconds =       0.42 minutes
-	total time  =         31 seconds =       0.52 minutes
+	user time   =      47.55 seconds =       0.79 minutes
+	system time =      12.21 seconds =       0.20 minutes
+	total time  =         17 seconds =       0.28 minutes
 Total time:
-	user time   =     131.69 seconds =       2.19 minutes
-	system time =      50.23 seconds =       0.84 minutes
-	total time  =         61 seconds =       1.02 minutes
-    REMP(0.10) Total Energy...............................................................PASSED
+	user time   =     108.21 seconds =       1.80 minutes
+	system time =      29.47 seconds =       0.49 minutes
+	total time  =         40 seconds =       0.67 minutes
+    DF-REMP(0.10) Total Energy............................................................PASSED
 
 Scratch directory: /scr/behnle/
     For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:01 2021
+*** at Wed Dec  1 19:15:17 2021
 
    => Loading Basis Set <=
 
@@ -1151,17 +1151,17 @@ Scratch directory: /scr/behnle/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -186.80596774561181   -1.86806e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.62701476001345   -8.21047e-01   7.28763e-03 DIIS
-   @DF-RHF iter   2:  -187.66737543111154   -4.03607e-02   5.43583e-03 DIIS
-   @DF-RHF iter   3:  -187.71367769619368   -4.63023e-02   2.57307e-04 DIIS
-   @DF-RHF iter   4:  -187.71388356409844   -2.05868e-04   5.64652e-05 DIIS
-   @DF-RHF iter   5:  -187.71389411996932   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter SAD:  -186.80596774561189   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001348   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111162   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619388   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409832   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996921   -1.05559e-05   1.18721e-05 DIIS
    @DF-RHF iter   6:  -187.71389474322558   -6.23256e-07   1.81898e-06 DIIS
-   @DF-RHF iter   7:  -187.71389476044715   -1.72216e-08   3.17692e-07 DIIS
-   @DF-RHF iter   8:  -187.71389476083473   -3.87587e-10   7.35240e-08 DIIS
-   @DF-RHF iter   9:  -187.71389476084647   -1.17382e-11   2.52664e-08 DIIS
-   @DF-RHF iter  10:  -187.71389476084755   -1.08002e-12   6.69961e-09 DIIS
+   @DF-RHF iter   7:  -187.71389476044695   -1.72214e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083476   -3.87814e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084607   -1.13118e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084744   -1.36424e-12   6.69960e-09 DIIS
   Energy and wave function converged.
 
 
@@ -1187,7 +1187,7 @@ Scratch directory: /scr/behnle/
       20Ap     0.877978    21Ap     0.980792    22Ap     1.190775  
        8App    1.190775    23Ap     1.241868    24Ap     1.492249  
       25Ap     1.547465     9App    1.571257    26Ap     1.571257  
-      27Ap     1.638718    10App    1.638718    28Ap     1.921537  
+      10App    1.638718    27Ap     1.638718    28Ap     1.921537  
       11App    1.921537    29Ap     1.935006    12App    2.177028  
       30Ap     2.177028    31Ap     2.293908    13App    2.293908  
       32Ap     2.548589    33Ap     2.705561    14App    2.840798  
@@ -1212,14 +1212,14 @@ Scratch directory: /scr/behnle/
              Ap   App 
     DOCC [     9,    2 ]
 
-  @DF-RHF Final Energy:  -187.71389476084755
+  @DF-RHF Final Energy:  -187.71389476084744
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             57.9389934488022433
-    One-Electron Energy =                -371.6693086840944034
-    Two-Electron Energy =                 126.0164204744446010
-    Total Energy =                       -187.7138947608475519
+    One-Electron Energy =                -371.6693086840940623
+    Two-Electron Energy =                 126.0164204744443737
+    Total Energy =                       -187.7138947608474382
 
 Computation Completed
 
@@ -1241,15 +1241,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
 
 
-*** tstop() called on south at Wed Dec  1 16:10:03 2021
+*** tstop() called on south at Wed Dec  1 19:15:18 2021
 Module time:
-	user time   =       3.10 seconds =       0.05 minutes
-	system time =       1.32 seconds =       0.02 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       4.06 seconds =       0.07 minutes
+	system time =       1.26 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
 Total time:
-	user time   =     134.82 seconds =       2.25 minutes
-	system time =      51.56 seconds =       0.86 minutes
-	total time  =         63 seconds =       1.05 minutes
+	user time   =     112.33 seconds =       1.87 minutes
+	system time =      30.73 seconds =       0.51 minutes
+	total time  =         41 seconds =       0.68 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -1273,7 +1273,7 @@ Total time:
 
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:04 2021
+*** at Wed Dec  1 19:15:19 2021
 
 
 
@@ -1432,10 +1432,10 @@ Total time:
 	Computing DF-MP2 energy ... 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	DF-HF Energy (a.u.)                :  -187.71389476084755
-	REF Energy (a.u.)                  :  -187.71389476084755
+	DF-HF Energy (a.u.)                :  -187.71389476084744
+	REF Energy (a.u.)                  :  -187.71389476084744
 	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
-	DF-MP2 Total Energy (a.u.)         :  -188.31461864796239
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796228
 	======================================================================= 
 	Using A=      0.2 as REMP mixing parameter
 
@@ -1445,19 +1445,19 @@ Total time:
 
   Iter       E_corr                  DE                 T2 RMS      
   ----   ----------------      ----------------       ----------    
-   1      -0.5868485452          0.0138753419         5.62e-05  
+   1      -0.5868485452          0.0138753419         3.72e-05  
    2      -0.5954836736         -0.0086351284         1.36e-05  
-   3      -0.5970024550         -0.0015187814         4.44e-06  
-   4      -0.5970034785         -0.0000010235         3.37e-07  
-   5      -0.5970258248         -0.0000223463         1.11e-07  
-   6      -0.5970288014         -0.0000029766         4.27e-08  
-   7      -0.5970285013          0.0000003001         1.00e-08  
-   8      -0.5970284604          0.0000000409         2.52e-09  
-   9      -0.5970284028          0.0000000576         9.33e-10  
-  10      -0.5970283927          0.0000000101         1.38e-10  
-  11      -0.5970283896          0.0000000031         3.00e-11  
-  12      -0.5970283885          0.0000000011         9.42e-12  
-  13      -0.5970283882          0.0000000002         2.92e-12  
+   3      -0.5970024550         -0.0015187814         3.99e-06  
+   4      -0.5970034785         -0.0000010235         8.13e-07  
+   5      -0.5970258248         -0.0000223463         2.03e-07  
+   6      -0.5970288014         -0.0000029766         3.55e-08  
+   7      -0.5970285013          0.0000003001         6.15e-09  
+   8      -0.5970284604          0.0000000409         3.30e-09  
+   9      -0.5970284028          0.0000000576         8.97e-10  
+  10      -0.5970283927          0.0000000101         1.48e-10  
+  11      -0.5970283896          0.0000000031         4.06e-11  
+  12      -0.5970283885          0.0000000011         7.17e-12  
+  13      -0.5970283882          0.0000000002         1.15e-12  
 
  ============================================================================== 
  ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
@@ -1467,29 +1467,29 @@ Total time:
 	================ REMP FINAL RESULTS =================================== 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	SCF Energy (a.u.)                  :  -187.71389476084755
-	REF Energy (a.u.)                  :  -187.71389476084755
+	SCF Energy (a.u.)                  :  -187.71389476084744
+	REF Energy (a.u.)                  :  -187.71389476084744
 	DF-REMP Correlation Energy (a.u.)  :    -0.59702838824625
-	DF-REMP Total Energy (a.u.)        :  -188.31092314909381
+	DF-REMP Total Energy (a.u.)        :  -188.31092314909370
 	======================================================================= 
 
 
-*** tstop() called on south at Wed Dec  1 16:10:31 2021
+*** tstop() called on south at Wed Dec  1 19:15:40 2021
 Module time:
-	user time   =      54.91 seconds =       0.92 minutes
-	system time =      21.67 seconds =       0.36 minutes
-	total time  =         27 seconds =       0.45 minutes
+	user time   =      48.42 seconds =       0.81 minutes
+	system time =      15.09 seconds =       0.25 minutes
+	total time  =         21 seconds =       0.35 minutes
 Total time:
-	user time   =     190.07 seconds =       3.17 minutes
-	system time =      73.39 seconds =       1.22 minutes
-	total time  =         91 seconds =       1.52 minutes
-    REMP(0.20) Total Energy...............................................................PASSED
+	user time   =     161.20 seconds =       2.69 minutes
+	system time =      45.99 seconds =       0.77 minutes
+	total time  =         63 seconds =       1.05 minutes
+    DF-REMP(0.20) Total Energy............................................................PASSED
 
 Scratch directory: /scr/behnle/
     For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:31 2021
+*** at Wed Dec  1 19:15:40 2021
 
    => Loading Basis Set <=
 
@@ -1608,17 +1608,17 @@ Scratch directory: /scr/behnle/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -186.80596774561192   -1.86806e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.62701476001371   -8.21047e-01   7.28763e-03 DIIS
-   @DF-RHF iter   2:  -187.66737543111151   -4.03607e-02   5.43583e-03 DIIS
-   @DF-RHF iter   3:  -187.71367769619380   -4.63023e-02   2.57307e-04 DIIS
-   @DF-RHF iter   4:  -187.71388356409818   -2.05868e-04   5.64652e-05 DIIS
-   @DF-RHF iter   5:  -187.71389411996907   -1.05559e-05   1.18721e-05 DIIS
-   @DF-RHF iter   6:  -187.71389474322561   -6.23257e-07   1.81898e-06 DIIS
-   @DF-RHF iter   7:  -187.71389476044709   -1.72215e-08   3.17692e-07 DIIS
-   @DF-RHF iter   8:  -187.71389476083465   -3.87558e-10   7.35240e-08 DIIS
-   @DF-RHF iter   9:  -187.71389476084644   -1.17950e-11   2.52664e-08 DIIS
-   @DF-RHF iter  10:  -187.71389476084761   -1.16529e-12   6.69961e-09 DIIS
+   @DF-RHF iter SAD:  -186.80596774561195   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001359   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111174   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619383   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409827   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996932   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322552   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044700   -1.72215e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083496   -3.87956e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084653   -1.15676e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084738   -8.52651e-13   6.69960e-09 DIIS
   Energy and wave function converged.
 
 
@@ -1669,14 +1669,14 @@ Scratch directory: /scr/behnle/
              Ap   App 
     DOCC [     9,    2 ]
 
-  @DF-RHF Final Energy:  -187.71389476084761
+  @DF-RHF Final Energy:  -187.71389476084738
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             57.9389934488022433
-    One-Electron Energy =                -371.6693086840940623
-    Two-Electron Energy =                 126.0164204744442031
-    Total Energy =                       -187.7138947608476087
+    One-Electron Energy =                -371.6693086840937212
+    Two-Electron Energy =                 126.0164204744440895
+    Total Energy =                       -187.7138947608473813
 
 Computation Completed
 
@@ -1698,15 +1698,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
 
 
-*** tstop() called on south at Wed Dec  1 16:10:32 2021
+*** tstop() called on south at Wed Dec  1 19:15:43 2021
 Module time:
-	user time   =       2.35 seconds =       0.04 minutes
-	system time =       1.06 seconds =       0.02 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       3.91 seconds =       0.07 minutes
+	system time =       1.46 seconds =       0.02 minutes
+	total time  =          3 seconds =       0.05 minutes
 Total time:
-	user time   =     192.45 seconds =       3.21 minutes
-	system time =      74.46 seconds =       1.24 minutes
-	total time  =         92 seconds =       1.53 minutes
+	user time   =     165.15 seconds =       2.75 minutes
+	system time =      47.48 seconds =       0.79 minutes
+	total time  =         66 seconds =       1.10 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -1730,7 +1730,7 @@ Total time:
 
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:33 2021
+*** at Wed Dec  1 19:15:44 2021
 
 
 
@@ -1889,10 +1889,10 @@ Total time:
 	Computing DF-MP2 energy ... 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	DF-HF Energy (a.u.)                :  -187.71389476084761
-	REF Energy (a.u.)                  :  -187.71389476084761
+	DF-HF Energy (a.u.)                :  -187.71389476084738
+	REF Energy (a.u.)                  :  -187.71389476084738
 	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
-	DF-MP2 Total Energy (a.u.)         :  -188.31461864796245
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796222
 	======================================================================= 
 	Using A=      0.3 as REMP mixing parameter
 
@@ -1902,17 +1902,17 @@ Total time:
 
   Iter       E_corr                  DE                 T2 RMS      
   ----   ----------------      ----------------       ----------    
-   1      -0.5885829629          0.0121409242         5.30e-05  
-   2      -0.5953280276         -0.0067450646         1.04e-05  
-   3      -0.5962379762         -0.0009099487         3.02e-06  
-   4      -0.5962336273          0.0000043489         5.63e-07  
-   5      -0.5962441174         -0.0000104900         8.08e-08  
-   6      -0.5962452429         -0.0000011256         1.53e-08  
-   7      -0.5962451337          0.0000001093         2.63e-09  
-   8      -0.5962451126          0.0000000211         9.49e-10  
-   9      -0.5962450980          0.0000000146         1.52e-10  
-  10      -0.5962450959          0.0000000021         2.59e-11  
-  11      -0.5962450954          0.0000000005         6.41e-12  
+   1      -0.5885829629          0.0121409242         4.59e-05  
+   2      -0.5953280276         -0.0067450646         1.41e-05  
+   3      -0.5962379762         -0.0009099487         3.75e-06  
+   4      -0.5962336273          0.0000043489         3.80e-07  
+   5      -0.5962441174         -0.0000104900         8.88e-08  
+   6      -0.5962452429         -0.0000011256         4.20e-09  
+   7      -0.5962451337          0.0000001093         3.47e-09  
+   8      -0.5962451126          0.0000000211         6.92e-10  
+   9      -0.5962450980          0.0000000146         1.87e-10  
+  10      -0.5962450959          0.0000000021         3.46e-11  
+  11      -0.5962450954          0.0000000005         6.29e-12  
 
  ============================================================================== 
  ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
@@ -1922,29 +1922,29 @@ Total time:
 	================ REMP FINAL RESULTS =================================== 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	SCF Energy (a.u.)                  :  -187.71389476084761
-	REF Energy (a.u.)                  :  -187.71389476084761
+	SCF Energy (a.u.)                  :  -187.71389476084738
+	REF Energy (a.u.)                  :  -187.71389476084738
 	DF-REMP Correlation Energy (a.u.)  :    -0.59624509538799
-	DF-REMP Total Energy (a.u.)        :  -188.31013985623559
+	DF-REMP Total Energy (a.u.)        :  -188.31013985623537
 	======================================================================= 
 
 
-*** tstop() called on south at Wed Dec  1 16:10:52 2021
+*** tstop() called on south at Wed Dec  1 19:16:29 2021
 Module time:
-	user time   =      44.09 seconds =       0.73 minutes
-	system time =      15.27 seconds =       0.25 minutes
-	total time  =         19 seconds =       0.32 minutes
+	user time   =      44.58 seconds =       0.74 minutes
+	system time =      21.59 seconds =       0.36 minutes
+	total time  =         45 seconds =       0.75 minutes
 Total time:
-	user time   =     236.89 seconds =       3.95 minutes
-	system time =      89.81 seconds =       1.50 minutes
+	user time   =     210.08 seconds =       3.50 minutes
+	system time =      69.15 seconds =       1.15 minutes
 	total time  =        112 seconds =       1.87 minutes
-    REMP(0.30) Total Energy...............................................................PASSED
+    DF-REMP(0.30) Total Energy............................................................PASSED
 
 Scratch directory: /scr/behnle/
     For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:52 2021
+*** at Wed Dec  1 19:16:29 2021
 
    => Loading Basis Set <=
 
@@ -2063,17 +2063,17 @@ Scratch directory: /scr/behnle/
 
                            Total Energy        Delta E     RMS |[F,P]|
 
-   @DF-RHF iter SAD:  -186.80596774561192   -1.86806e+02   0.00000e+00 
-   @DF-RHF iter   1:  -187.62701476001337   -8.21047e-01   7.28763e-03 DIIS
-   @DF-RHF iter   2:  -187.66737543111168   -4.03607e-02   5.43583e-03 DIIS
-   @DF-RHF iter   3:  -187.71367769619380   -4.63023e-02   2.57307e-04 DIIS
-   @DF-RHF iter   4:  -187.71388356409841   -2.05868e-04   5.64652e-05 DIIS
-   @DF-RHF iter   5:  -187.71389411996941   -1.05559e-05   1.18721e-05 DIIS
-   @DF-RHF iter   6:  -187.71389474322592   -6.23257e-07   1.81898e-06 DIIS
-   @DF-RHF iter   7:  -187.71389476044692   -1.72210e-08   3.17692e-07 DIIS
-   @DF-RHF iter   8:  -187.71389476083471   -3.87786e-10   7.35240e-08 DIIS
-   @DF-RHF iter   9:  -187.71389476084627   -1.15676e-11   2.52664e-08 DIIS
-   @DF-RHF iter  10:  -187.71389476084752   -1.25056e-12   6.69961e-09 DIIS
+   @DF-RHF iter SAD:  -186.80596774561181   -1.86806e+02   0.00000e+00 
+   @DF-RHF iter   1:  -187.62701476001365   -8.21047e-01   7.28763e-03 DIIS
+   @DF-RHF iter   2:  -187.66737543111154   -4.03607e-02   5.43583e-03 DIIS
+   @DF-RHF iter   3:  -187.71367769619368   -4.63023e-02   2.57307e-04 DIIS
+   @DF-RHF iter   4:  -187.71388356409827   -2.05868e-04   5.64652e-05 DIIS
+   @DF-RHF iter   5:  -187.71389411996924   -1.05559e-05   1.18721e-05 DIIS
+   @DF-RHF iter   6:  -187.71389474322564   -6.23256e-07   1.81898e-06 DIIS
+   @DF-RHF iter   7:  -187.71389476044703   -1.72214e-08   3.17692e-07 DIIS
+   @DF-RHF iter   8:  -187.71389476083479   -3.87757e-10   7.35240e-08 DIIS
+   @DF-RHF iter   9:  -187.71389476084633   -1.15392e-11   2.52664e-08 DIIS
+   @DF-RHF iter  10:  -187.71389476084761   -1.27898e-12   6.69960e-09 DIIS
   Energy and wave function converged.
 
 
@@ -2124,14 +2124,14 @@ Scratch directory: /scr/behnle/
              Ap   App 
     DOCC [     9,    2 ]
 
-  @DF-RHF Final Energy:  -187.71389476084752
+  @DF-RHF Final Energy:  -187.71389476084761
 
    => Energetics <=
 
     Nuclear Repulsion Energy =             57.9389934488022433
     One-Electron Energy =                -371.6693086840940055
-    Two-Electron Energy =                 126.0164204744442316
-    Total Energy =                       -187.7138947608475235
+    Two-Electron Energy =                 126.0164204744441605
+    Total Energy =                       -187.7138947608476087
 
 Computation Completed
 
@@ -2153,15 +2153,15 @@ Properties computed using the SCF density matrix
      X:    -0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
 
 
-*** tstop() called on south at Wed Dec  1 16:10:53 2021
+*** tstop() called on south at Wed Dec  1 19:16:33 2021
 Module time:
-	user time   =       3.79 seconds =       0.06 minutes
-	system time =       1.33 seconds =       0.02 minutes
-	total time  =          1 seconds =       0.02 minutes
+	user time   =       3.73 seconds =       0.06 minutes
+	system time =       1.45 seconds =       0.02 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =     240.71 seconds =       4.01 minutes
-	system time =      91.17 seconds =       1.52 minutes
-	total time  =        113 seconds =       1.88 minutes
+	user time   =     213.83 seconds =       3.56 minutes
+	system time =      70.62 seconds =       1.18 minutes
+	total time  =        116 seconds =       1.93 minutes
 
   A requested method does not make use of molecular symmetry: further calculations in C1 point group.
 
@@ -2185,7 +2185,7 @@ Total time:
 
 
 *** tstart() called on south
-*** at Wed Dec  1 16:10:54 2021
+*** at Wed Dec  1 19:16:34 2021
 
 
 
@@ -2344,10 +2344,10 @@ Total time:
 	Computing DF-MP2 energy ... 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	DF-HF Energy (a.u.)                :  -187.71389476084752
-	REF Energy (a.u.)                  :  -187.71389476084752
+	DF-HF Energy (a.u.)                :  -187.71389476084761
+	REF Energy (a.u.)                  :  -187.71389476084761
 	DF-MP2 Correlation Energy (a.u.)   :    -0.60072388711485
-	DF-MP2 Total Energy (a.u.)         :  -188.31461864796236
+	DF-MP2 Total Energy (a.u.)         :  -188.31461864796245
 	======================================================================= 
 	Using A=        1 as REMP mixing parameter
 
@@ -2357,7 +2357,7 @@ Total time:
 
   Iter       E_corr                  DE                 T2 RMS      
   ----   ----------------      ----------------       ----------    
-   1      -0.6007238871          0.0000000000         3.00e-20  
+   1      -0.6007238871          0.0000000000         3.77e-20  
 
  ============================================================================== 
  ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
@@ -2367,25 +2367,25 @@ Total time:
 	================ REMP FINAL RESULTS =================================== 
 	======================================================================= 
 	Nuclear Repulsion Energy (a.u.)    :    57.93899344880224
-	SCF Energy (a.u.)                  :  -187.71389476084752
-	REF Energy (a.u.)                  :  -187.71389476084752
+	SCF Energy (a.u.)                  :  -187.71389476084761
+	REF Energy (a.u.)                  :  -187.71389476084761
 	DF-REMP Correlation Energy (a.u.)  :    -0.60072388711485
-	DF-REMP Total Energy (a.u.)        :  -188.31461864796236
+	DF-REMP Total Energy (a.u.)        :  -188.31461864796245
 	======================================================================= 
 
 
-*** tstop() called on south at Wed Dec  1 16:10:56 2021
+*** tstop() called on south at Wed Dec  1 19:16:38 2021
 Module time:
-	user time   =       4.94 seconds =       0.08 minutes
-	system time =       1.86 seconds =       0.03 minutes
-	total time  =          2 seconds =       0.03 minutes
+	user time   =       4.79 seconds =       0.08 minutes
+	system time =       2.40 seconds =       0.04 minutes
+	total time  =          4 seconds =       0.07 minutes
 Total time:
-	user time   =     246.06 seconds =       4.10 minutes
-	system time =      93.22 seconds =       1.55 minutes
-	total time  =        116 seconds =       1.93 minutes
-    REMP(1.00) Total Energy...............................................................PASSED
+	user time   =     218.94 seconds =       3.65 minutes
+	system time =      73.10 seconds =       1.22 minutes
+	total time  =        121 seconds =       2.02 minutes
+    DF-REMP(1.00) Total Energy............................................................PASSED
 
-    Psi4 stopped on: Wednesday, 01 December 2021 04:10PM
-    Psi4 wall time for execution: 0:01:55.31
+    Psi4 stopped on: Wednesday, 01 December 2021 07:16PM
+    Psi4 wall time for execution: 0:02:01.14
 
 *** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/dfremp-2/CMakeLists.txt
+++ b/tests/dfremp-2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(dfremp-2 "psi;dfocc")

--- a/tests/dfremp-2/input.dat
+++ b/tests/dfremp-2/input.dat
@@ -1,0 +1,70 @@
+#! density fitted REMP/cc-pVDZ energies for the CH3 radical
+
+test_dict = { "0.00": -39.68419847959576,  #TEST
+              "0.10": -39.68080529893142,  #TEST
+              "0.20": -39.67771577720799,  #TEST
+              "0.30": -39.67486705961197,  #TEST
+              "1.00": -39.65922066911472 } #TEST
+
+ESCF = -39.53295512364772
+
+
+molecule ch3 {
+units bohr
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000      
+H    1.02022495761968     -1.76708146174709      0.00000000000000      
+H    1.02022495761968      1.76708146174709      0.00000000000000      
+H   -2.04044991523936      0.00000000000000      0.00000000000000      
+}
+
+
+
+set {
+  reference uhf
+  basis def2-SVP
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-SVP-ri
+  freeze_core true
+  cc_type df
+  mp2_type df
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(1.00) Total Energy") #TEST
+

--- a/tests/dfremp-2/output.ref
+++ b/tests/dfremp-2/output.ref
@@ -1,0 +1,2518 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 71fed73 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 01 December 2021 07:32PM
+
+    Process ID: 27120
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! density fitted REMP/cc-pVDZ energies for the CH3 radical
+
+test_dict = { "0.00": -39.68419847959576,  #TEST
+              "0.10": -39.68080529893142,  #TEST
+              "0.20": -39.67771577720799,  #TEST
+              "0.30": -39.67486705961197,  #TEST
+              "1.00": -39.65922066911472 } #TEST
+
+ESCF = -39.53295512364772
+
+
+molecule ch3 {
+units bohr
+0 2
+C    0.00000000000000      0.00000000000000      0.00000000000000      
+H    1.02022495761968     -1.76708146174709      0.00000000000000      
+H    1.02022495761968      1.76708146174709      0.00000000000000      
+H   -2.04044991523936      0.00000000000000      0.00000000000000      
+}
+
+
+
+set {
+  reference uhf
+  basis def2-SVP
+  df_basis_scf def2-universal-jkfit
+  df_basis_cc def2-SVP-ri
+  freeze_core true
+  cc_type df
+  mp2_type df
+}  
+
+set{
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+}
+
+#Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(ESCF, variable("SCF TOTAL ENERGY"), 6, "DF-SCF Energy") #TEST
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.00) Total Energy") #TEST
+
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 7, "DF-REMP(1.00) Total Energy") #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:32:41 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 43
+    Number of basis functions: 129
+    Number of Cartesian functions: 149
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -38.88372373441972   -3.88837e+01   0.00000e+00 
+   @DF-UHF iter   1:   -39.50941618985412   -6.25692e-01   1.07563e-02 DIIS
+   @DF-UHF iter   2:   -39.53040270644636   -2.09865e-02   3.21260e-03 DIIS
+   @DF-UHF iter   3:   -39.53245659545384   -2.05389e-03   1.08247e-03 DIIS
+   @DF-UHF iter   4:   -39.53285331370146   -3.96718e-04   4.03469e-04 DIIS
+   @DF-UHF iter   5:   -39.53294476908412   -9.14554e-05   1.26072e-04 DIIS
+   @DF-UHF iter   6:   -39.53295493441212   -1.01653e-05   1.85279e-05 DIIS
+   @DF-UHF iter   7:   -39.53295511744076   -1.83029e-07   3.82090e-06 DIIS
+   @DF-UHF iter   8:   -39.53295512360480   -6.16404e-09   3.78050e-07 DIIS
+   @DF-UHF iter   9:   -39.53295512364726   -4.24620e-11   3.74686e-08 DIIS
+   @DF-UHF iter  10:   -39.53295512364772   -4.54747e-13   5.26310e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112033678E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611203368E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240566     2A1    -0.935251     3A1    -0.579646  
+       1B1    -0.579646     1B2    -0.386086  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196545     5A1     0.268767     2B1     0.268767  
+       3B1     0.620164     6A1     0.620164     7A1     0.644642  
+       2B2     0.672201     8A1     0.855942     9A1     0.937448  
+       4B1     0.937448     3B2     1.436603     1A2     1.436603  
+       5B1     1.749587     6B1     1.876742    10A1     1.876742  
+       4B2     2.009872    11A1     2.115982     2A2     2.527650  
+       5B2     2.527650    12A1     2.558157     7B1     2.558157  
+      13A1     3.201379    14A1     3.281707     8B1     3.281707  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215592     2A1    -0.844572     1B1    -0.564475  
+       3A1    -0.564475  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141500     4A1     0.212944     5A1     0.275883  
+       2B1     0.275883     3B1     0.624722     6A1     0.624722  
+       7A1     0.687510     2B2     0.819870     8A1     0.889510  
+       9A1     0.950802     4B1     0.950802     3B2     1.487454  
+       1A2     1.487454     5B1     1.744885     6B1     1.879261  
+      10A1     1.879261     4B2     2.021879    11A1     2.198084  
+      12A1     2.562498     7B1     2.562498     2A2     2.580976  
+       5B2     2.580976    13A1     3.215399    14A1     3.293043  
+       8B1     3.293043  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:   -39.53295512364772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4964841267354956
+    Two-Electron Energy =                  22.2930878615544579
+    Total Energy =                        -39.5329551236477243
+
+  UHF NO Occupations:
+  HONO-2 :    1 B1 1.9990580
+  HONO-1 :    3 A1 1.9963167
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036833
+  LUNO+1 :    2 B1 0.0009420
+  LUNO+2 :    5 A1 0.0009420
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 19:32:43 2021
+Module time:
+	user time   =       3.88 seconds =       0.06 minutes
+	system time =       1.44 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       3.88 seconds =       0.06 minutes
+	system time =       1.44 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   153 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:32:43 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-SVP-RI     !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+
+	Number of basis functions in the DF-CC basis:  90
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.94 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.75 MB 
+	Memory requirement for Wabef term     :      0.97 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	DF-HF Energy (a.u.)                :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	Scaled_SS Correlation Energy (a.u.):    -0.00797878612141
+	Scaled_OS Correlation Energy (a.u.):    -0.12279502452332
+	DF-SCS-MP2 Total Energy (a.u.)     :   -39.66372893429244
+	DF-SOS-MP2 Total Energy (a.u.)     :   -39.66598306688131
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -39.57508311436874
+	DF-MP2 Correlation Energy (a.u.)   :    -0.12626554546698
+	DF-MP2 Total Energy (a.u.)         :   -39.65922066911470
+	======================================================================= 
+	Using A=        0 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1447932745         -0.0185277290         3.18e-04  
+   2      -0.1507696820         -0.0059764075         1.50e-04  
+   3      -0.1511910822         -0.0004214001         9.96e-05  
+   4      -0.1512254894         -0.0000344072         5.24e-05  
+   5      -0.1512398604         -0.0000143711         1.37e-05  
+   6      -0.1512442714         -0.0000044109         2.62e-06  
+   7      -0.1512433031          0.0000009683         6.99e-07  
+   8      -0.1512430799          0.0000002232         2.53e-07  
+   9      -0.1512432211         -0.0000001413         2.05e-08  
+  10      -0.1512433122         -0.0000000910         1.40e-08  
+  11      -0.1512433427         -0.0000000305         3.12e-09  
+  12      -0.1512433509         -0.0000000083         2.58e-09  
+  13      -0.1512433545         -0.0000000036         1.67e-09  
+  14      -0.1512433559         -0.0000000014         5.70e-10  
+  15      -0.1512433559         -0.0000000001         1.10e-10  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01839570342590
+	Beta-Beta Contribution (a.u.)      :    -0.00597493767480
+	Alpha-Beta Contribution (a.u.)     :    -0.12687271484732
+	DF-REMP Correlation Energy (a.u.)  :    -0.15124335594803
+	DF-REMP Total Energy (a.u.)        :   -39.68419847959574
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:33:01 2021
+Module time:
+	user time   =      44.98 seconds =       0.75 minutes
+	system time =      17.79 seconds =       0.30 minutes
+	total time  =         18 seconds =       0.30 minutes
+Total time:
+	user time   =      49.35 seconds =       0.82 minutes
+	system time =      19.29 seconds =       0.32 minutes
+	total time  =         20 seconds =       0.33 minutes
+    DF-SCF Energy.........................................................................PASSED
+    DF-REMP(0.00) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:01 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000    -0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000    -0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 43
+    Number of basis functions: 129
+    Number of Cartesian functions: 149
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -38.88372373441969   -3.88837e+01   0.00000e+00 
+   @DF-UHF iter   1:   -39.50941618985415   -6.25692e-01   1.07563e-02 DIIS
+   @DF-UHF iter   2:   -39.53040270644634   -2.09865e-02   3.21260e-03 DIIS
+   @DF-UHF iter   3:   -39.53245659545387   -2.05389e-03   1.08247e-03 DIIS
+   @DF-UHF iter   4:   -39.53285331370147   -3.96718e-04   4.03469e-04 DIIS
+   @DF-UHF iter   5:   -39.53294476908414   -9.14554e-05   1.26072e-04 DIIS
+   @DF-UHF iter   6:   -39.53295493441211   -1.01653e-05   1.85279e-05 DIIS
+   @DF-UHF iter   7:   -39.53295511744075   -1.83029e-07   3.82090e-06 DIIS
+   @DF-UHF iter   8:   -39.53295512360480   -6.16405e-09   3.78050e-07 DIIS
+   @DF-UHF iter   9:   -39.53295512364728   -4.24834e-11   3.74686e-08 DIIS
+   @DF-UHF iter  10:   -39.53295512364772   -4.33431e-13   5.26310e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112033678E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611203368E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240566     2A1    -0.935251     3A1    -0.579646  
+       1B1    -0.579646     1B2    -0.386086  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196545     5A1     0.268767     2B1     0.268767  
+       3B1     0.620164     6A1     0.620164     7A1     0.644642  
+       2B2     0.672201     8A1     0.855942     9A1     0.937448  
+       4B1     0.937448     3B2     1.436603     1A2     1.436603  
+       5B1     1.749587     6B1     1.876742    10A1     1.876742  
+       4B2     2.009872    11A1     2.115982     2A2     2.527650  
+       5B2     2.527650    12A1     2.558157     7B1     2.558157  
+      13A1     3.201379    14A1     3.281707     8B1     3.281707  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215592     2A1    -0.844572     3A1    -0.564475  
+       1B1    -0.564475  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141500     4A1     0.212944     5A1     0.275883  
+       2B1     0.275883     3B1     0.624722     6A1     0.624722  
+       7A1     0.687510     2B2     0.819870     8A1     0.889510  
+       9A1     0.950802     4B1     0.950802     3B2     1.487454  
+       1A2     1.487454     5B1     1.744885     6B1     1.879261  
+      10A1     1.879261     4B2     2.021879    11A1     2.198084  
+      12A1     2.562498     7B1     2.562498     2A2     2.580976  
+       5B2     2.580976    13A1     3.215399    14A1     3.293043  
+       8B1     3.293043  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:   -39.53295512364772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4964841267354956
+    Two-Electron Energy =                  22.2930878615544614
+    Total Energy =                        -39.5329551236477172
+
+  UHF NO Occupations:
+  HONO-2 :    1 B1 1.9990580
+  HONO-1 :    3 A1 1.9963167
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036833
+  LUNO+1 :    2 B1 0.0009420
+  LUNO+2 :    5 A1 0.0009420
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 19:33:02 2021
+Module time:
+	user time   =       3.09 seconds =       0.05 minutes
+	system time =       1.01 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      52.47 seconds =       0.87 minutes
+	system time =      20.30 seconds =       0.34 minutes
+	total time  =         21 seconds =       0.35 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   153 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:02 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-SVP-RI     !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+
+	Number of basis functions in the DF-CC basis:  90
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.94 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.75 MB 
+	Memory requirement for Wabef term     :      0.97 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	DF-HF Energy (a.u.)                :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	Scaled_SS Correlation Energy (a.u.):    -0.00797878612141
+	Scaled_OS Correlation Energy (a.u.):    -0.12279502452332
+	DF-SCS-MP2 Total Energy (a.u.)     :   -39.66372893429244
+	DF-SOS-MP2 Total Energy (a.u.)     :   -39.66598306688131
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -39.57508311436874
+	DF-MP2 Correlation Energy (a.u.)   :    -0.12626554546698
+	DF-MP2 Total Energy (a.u.)         :   -39.65922066911470
+	======================================================================= 
+	Using A=      0.1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1429405016         -0.0166749561         2.86e-04  
+   2      -0.1476163065         -0.0046758049         1.68e-04  
+   3      -0.1478398851         -0.0002235786         6.31e-05  
+   4      -0.1478441112         -0.0000042262         4.25e-06  
+   5      -0.1478490483         -0.0000049370         5.14e-06  
+   6      -0.1478505052         -0.0000014569         9.08e-07  
+   7      -0.1478501506          0.0000003546         2.27e-07  
+   8      -0.1478501033          0.0000000473         6.44e-08  
+   9      -0.1478501467         -0.0000000434         1.28e-08  
+  10      -0.1478501678         -0.0000000211         3.05e-09  
+  11      -0.1478501736         -0.0000000058         8.63e-10  
+  12      -0.1478501749         -0.0000000013         1.15e-10  
+  13      -0.1478501753         -0.0000000004         2.21e-10  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01839717663684
+	Beta-Beta Contribution (a.u.)      :    -0.00604461221872
+	Alpha-Beta Contribution (a.u.)     :    -0.12340838642814
+	DF-REMP Correlation Energy (a.u.)  :    -0.14785017528370
+	DF-REMP Total Energy (a.u.)        :   -39.68080529893142
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:33:18 2021
+Module time:
+	user time   =      40.76 seconds =       0.68 minutes
+	system time =      15.52 seconds =       0.26 minutes
+	total time  =         16 seconds =       0.27 minutes
+Total time:
+	user time   =      93.69 seconds =       1.56 minutes
+	system time =      35.87 seconds =       0.60 minutes
+	total time  =         37 seconds =       0.62 minutes
+    DF-REMP(0.10) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:18 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 43
+    Number of basis functions: 129
+    Number of Cartesian functions: 149
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -38.88372373441968   -3.88837e+01   0.00000e+00 
+   @DF-UHF iter   1:   -39.50941618985411   -6.25692e-01   1.07563e-02 DIIS
+   @DF-UHF iter   2:   -39.53040270644637   -2.09865e-02   3.21260e-03 DIIS
+   @DF-UHF iter   3:   -39.53245659545386   -2.05389e-03   1.08247e-03 DIIS
+   @DF-UHF iter   4:   -39.53285331370148   -3.96718e-04   4.03469e-04 DIIS
+   @DF-UHF iter   5:   -39.53294476908413   -9.14554e-05   1.26072e-04 DIIS
+   @DF-UHF iter   6:   -39.53295493441211   -1.01653e-05   1.85279e-05 DIIS
+   @DF-UHF iter   7:   -39.53295511744078   -1.83029e-07   3.82090e-06 DIIS
+   @DF-UHF iter   8:   -39.53295512360482   -6.16404e-09   3.78050e-07 DIIS
+   @DF-UHF iter   9:   -39.53295512364729   -4.24691e-11   3.74686e-08 DIIS
+   @DF-UHF iter  10:   -39.53295512364773   -4.40536e-13   5.26310e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112033678E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611203368E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240566     2A1    -0.935251     3A1    -0.579646  
+       1B1    -0.579646     1B2    -0.386086  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196545     5A1     0.268767     2B1     0.268767  
+       3B1     0.620164     6A1     0.620164     7A1     0.644642  
+       2B2     0.672201     8A1     0.855942     9A1     0.937448  
+       4B1     0.937448     3B2     1.436603     1A2     1.436603  
+       5B1     1.749587     6B1     1.876742    10A1     1.876742  
+       4B2     2.009872    11A1     2.115982     2A2     2.527650  
+       5B2     2.527650    12A1     2.558157     7B1     2.558157  
+      13A1     3.201379    14A1     3.281707     8B1     3.281707  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215592     2A1    -0.844572     3A1    -0.564475  
+       1B1    -0.564475  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141500     4A1     0.212944     5A1     0.275883  
+       2B1     0.275883     3B1     0.624722     6A1     0.624722  
+       7A1     0.687510     2B2     0.819870     8A1     0.889510  
+       9A1     0.950802     4B1     0.950802     3B2     1.487454  
+       1A2     1.487454     5B1     1.744885     6B1     1.879261  
+      10A1     1.879261     4B2     2.021879    11A1     2.198084  
+      12A1     2.562498     7B1     2.562498     2A2     2.580976  
+       5B2     2.580976    13A1     3.215399    14A1     3.293043  
+       8B1     3.293043  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:   -39.53295512364773
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4964841267355098
+    Two-Electron Energy =                  22.2930878615544650
+    Total Energy =                        -39.5329551236477243
+
+  UHF NO Occupations:
+  HONO-2 :    1 B1 1.9990580
+  HONO-1 :    3 A1 1.9963167
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036833
+  LUNO+1 :    2 B1 0.0009420
+  LUNO+2 :    5 A1 0.0009420
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 19:33:19 2021
+Module time:
+	user time   =       2.26 seconds =       0.04 minutes
+	system time =       0.72 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      95.98 seconds =       1.60 minutes
+	system time =      36.61 seconds =       0.61 minutes
+	total time  =         38 seconds =       0.63 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   153 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:19 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-SVP-RI     !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+
+	Number of basis functions in the DF-CC basis:  90
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.94 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.75 MB 
+	Memory requirement for Wabef term     :      0.97 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	DF-HF Energy (a.u.)                :   -39.53295512364773
+	REF Energy (a.u.)                  :   -39.53295512364773
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	Scaled_SS Correlation Energy (a.u.):    -0.00797878612141
+	Scaled_OS Correlation Energy (a.u.):    -0.12279502452332
+	DF-SCS-MP2 Total Energy (a.u.)     :   -39.66372893429245
+	DF-SOS-MP2 Total Energy (a.u.)     :   -39.66598306688132
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -39.57508311436875
+	DF-MP2 Correlation Energy (a.u.)   :    -0.12626554546698
+	DF-MP2 Total Energy (a.u.)         :   -39.65922066911471
+	======================================================================= 
+	Using A=      0.2 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1410877287         -0.0148221832         3.16e-04  
+   2      -0.1446535098         -0.0035657811         8.95e-05  
+   3      -0.1447616311         -0.0001081213         3.94e-05  
+   4      -0.1447583746          0.0000032565         1.25e-05  
+   5      -0.1447602740         -0.0000018993         2.01e-06  
+   6      -0.1447607632         -0.0000004892         3.06e-07  
+   7      -0.1447606442          0.0000001189         2.76e-08  
+   8      -0.1447606362          0.0000000080         1.63e-08  
+   9      -0.1447606481         -0.0000000119         2.74e-09  
+  10      -0.1447606526         -0.0000000045         5.66e-10  
+  11      -0.1447606536         -0.0000000010         1.71e-10  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53295512364773
+	REF Energy (a.u.)                  :   -39.53295512364773
+	Alpha-Alpha Contribution (a.u.)    :    -0.01837378781253
+	Beta-Beta Contribution (a.u.)      :    -0.00609670970188
+	Alpha-Beta Contribution (a.u.)     :    -0.12029015604587
+	DF-REMP Correlation Energy (a.u.)  :    -0.14476065356028
+	DF-REMP Total Energy (a.u.)        :   -39.67771577720801
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:33:32 2021
+Module time:
+	user time   =      35.33 seconds =       0.59 minutes
+	system time =      13.08 seconds =       0.22 minutes
+	total time  =         13 seconds =       0.22 minutes
+Total time:
+	user time   =     131.77 seconds =       2.20 minutes
+	system time =      49.77 seconds =       0.83 minutes
+	total time  =         51 seconds =       0.85 minutes
+    DF-REMP(0.20) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:32 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000    -0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000    -0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 43
+    Number of basis functions: 129
+    Number of Cartesian functions: 149
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -38.88372373441970   -3.88837e+01   0.00000e+00 
+   @DF-UHF iter   1:   -39.50941618985409   -6.25692e-01   1.07563e-02 DIIS
+   @DF-UHF iter   2:   -39.53040270644634   -2.09865e-02   3.21260e-03 DIIS
+   @DF-UHF iter   3:   -39.53245659545385   -2.05389e-03   1.08247e-03 DIIS
+   @DF-UHF iter   4:   -39.53285331370146   -3.96718e-04   4.03469e-04 DIIS
+   @DF-UHF iter   5:   -39.53294476908412   -9.14554e-05   1.26072e-04 DIIS
+   @DF-UHF iter   6:   -39.53295493441209   -1.01653e-05   1.85279e-05 DIIS
+   @DF-UHF iter   7:   -39.53295511744076   -1.83029e-07   3.82090e-06 DIIS
+   @DF-UHF iter   8:   -39.53295512360482   -6.16406e-09   3.78050e-07 DIIS
+   @DF-UHF iter   9:   -39.53295512364728   -4.24549e-11   3.74686e-08 DIIS
+   @DF-UHF iter  10:   -39.53295512364772   -4.47642e-13   5.26310e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112033678E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611203368E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240566     2A1    -0.935251     3A1    -0.579646  
+       1B1    -0.579646     1B2    -0.386086  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196545     5A1     0.268767     2B1     0.268767  
+       3B1     0.620164     6A1     0.620164     7A1     0.644642  
+       2B2     0.672201     8A1     0.855942     9A1     0.937448  
+       4B1     0.937448     3B2     1.436603     1A2     1.436603  
+       5B1     1.749587     6B1     1.876742    10A1     1.876742  
+       4B2     2.009872    11A1     2.115982     2A2     2.527650  
+       5B2     2.527650    12A1     2.558157     7B1     2.558157  
+      13A1     3.201379    14A1     3.281707     8B1     3.281707  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215592     2A1    -0.844572     3A1    -0.564475  
+       1B1    -0.564475  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141500     4A1     0.212944     5A1     0.275883  
+       2B1     0.275883     3B1     0.624722     6A1     0.624722  
+       7A1     0.687510     2B2     0.819870     8A1     0.889510  
+       9A1     0.950802     4B1     0.950802     3B2     1.487454  
+       1A2     1.487454     5B1     1.744885     6B1     1.879261  
+      10A1     1.879261     4B2     2.021879    11A1     2.198084  
+      12A1     2.562498     7B1     2.562498     2A2     2.580976  
+       5B2     2.580976    13A1     3.215399    14A1     3.293043  
+       8B1     3.293043  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:   -39.53295512364772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4964841267355098
+    Two-Electron Energy =                  22.2930878615544685
+    Total Energy =                        -39.5329551236477243
+
+  UHF NO Occupations:
+  HONO-2 :    1 B1 1.9990580
+  HONO-1 :    3 A1 1.9963167
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036833
+  LUNO+1 :    2 B1 0.0009420
+  LUNO+2 :    5 A1 0.0009420
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 19:33:33 2021
+Module time:
+	user time   =       2.95 seconds =       0.05 minutes
+	system time =       0.97 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     134.75 seconds =       2.25 minutes
+	system time =      50.76 seconds =       0.85 minutes
+	total time  =         52 seconds =       0.87 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   153 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:34 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-SVP-RI     !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+
+	Number of basis functions in the DF-CC basis:  90
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.94 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.75 MB 
+	Memory requirement for Wabef term     :      0.97 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	DF-HF Energy (a.u.)                :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	Scaled_SS Correlation Energy (a.u.):    -0.00797878612141
+	Scaled_OS Correlation Energy (a.u.):    -0.12279502452332
+	DF-SCS-MP2 Total Energy (a.u.)     :   -39.66372893429244
+	DF-SOS-MP2 Total Energy (a.u.)     :   -39.66598306688132
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -39.57508311436874
+	DF-MP2 Correlation Energy (a.u.)   :    -0.12626554546698
+	DF-MP2 Total Energy (a.u.)         :   -39.65922066911470
+	======================================================================= 
+	Using A=      0.3 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1392349558         -0.0129694103         2.22e-04  
+   2      -0.1418688750         -0.0026339192         8.17e-05  
+   3      -0.1419145296         -0.0000456546         5.90e-06  
+   4      -0.1419110474          0.0000034823         5.80e-06  
+   5      -0.1419118155         -0.0000007682         7.31e-07  
+   6      -0.1419119729         -0.0000001573         9.38e-08  
+   7      -0.1419119367          0.0000000361         1.95e-08  
+   8      -0.1419119360          0.0000000008         4.01e-09  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01833127779744
+	Beta-Beta Contribution (a.u.)      :    -0.00613488149547
+	Alpha-Beta Contribution (a.u.)     :    -0.11744577667132
+	DF-REMP Correlation Energy (a.u.)  :    -0.14191193596422
+	DF-REMP Total Energy (a.u.)        :   -39.67486705961195
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:33:44 2021
+Module time:
+	user time   =      25.40 seconds =       0.42 minutes
+	system time =      10.16 seconds =       0.17 minutes
+	total time  =         10 seconds =       0.17 minutes
+Total time:
+	user time   =     160.62 seconds =       2.68 minutes
+	system time =      60.98 seconds =       1.02 minutes
+	total time  =         63 seconds =       1.05 minutes
+    DF-REMP(0.30) Total Energy............................................................PASSED
+
+Scratch directory: /scr/behnle/
+    For method 'REMP', SCF Algorithm Type (re)set to DISK_DF.
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:44 2021
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry C          line    90 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+    atoms 2-4 entry H          line    15 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c2v
+    Full point group: D3h
+
+    Geometry (in Bohr), charge = 0, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         C            0.000000000000     0.000000000000     0.000000000000    12.000000000000
+         H            0.000000000000     0.000000000000    -2.040449915239     1.007825032230
+         H            1.767081461747     0.000000000000     1.020224957620     1.007825032230
+         H           -1.767081461747    -0.000000000000     1.020224957620     1.007825032230
+
+  Running in c2v symmetry.
+
+  Rotational constants: A =      9.56458  B =      9.56458  C =      4.78229 [cm^-1]
+  Rotational constants: A = 286738.92683  B = 286738.92683  C = 143369.46342 [MHz]
+  Nuclear repulsion =    9.670441141533317
+
+  Charge       = 0
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is DISK_DF.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: DEF2-SVP
+    Blend: DEF2-SVP
+    Number of shells: 15
+    Number of basis functions: 29
+    Number of Cartesian functions: 30
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+  ==> Integral Setup <==
+
+  ==> DiskDFJK: Density-Fitted J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    OpenMP threads:              4
+    Integrals threads:           4
+    Memory [MiB]:              375
+    Algorithm:                Core
+    Integral Cache:           SAVE
+    Schwarz Cutoff:          1E-12
+    Fitting Condition:       1E-10
+
+   => Auxiliary Basis Set <=
+
+  Basis Set: DEF2-UNIVERSAL-JKFIT
+    Blend: DEF2-UNIVERSAL-JKFIT
+    Number of shells: 43
+    Number of basis functions: 129
+    Number of Cartesian functions: 149
+    Spherical Harmonics?: true
+    Max angular momentum: 4
+
+  Minimum eigenvalue in the overlap matrix is 2.0564462170E-02.
+  Reciprocal condition number of the overlap matrix is 5.1650050145E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A1        14      14 
+     A2         2       2 
+     B1         8       8 
+     B2         5       5 
+   -------------------------
+    Total      29      29
+   -------------------------
+
+  ==> Iterations <==
+
+                           Total Energy        Delta E     RMS |[F,P]|
+
+   @DF-UHF iter SAD:   -38.88372373441969   -3.88837e+01   0.00000e+00 
+   @DF-UHF iter   1:   -39.50941618985409   -6.25692e-01   1.07563e-02 DIIS
+   @DF-UHF iter   2:   -39.53040270644638   -2.09865e-02   3.21260e-03 DIIS
+   @DF-UHF iter   3:   -39.53245659545386   -2.05389e-03   1.08247e-03 DIIS
+   @DF-UHF iter   4:   -39.53285331370149   -3.96718e-04   4.03469e-04 DIIS
+   @DF-UHF iter   5:   -39.53294476908413   -9.14554e-05   1.26072e-04 DIIS
+   @DF-UHF iter   6:   -39.53295493441210   -1.01653e-05   1.85279e-05 DIIS
+   @DF-UHF iter   7:   -39.53295511744077   -1.83029e-07   3.82090e-06 DIIS
+   @DF-UHF iter   8:   -39.53295512360481   -6.16404e-09   3.78050e-07 DIIS
+   @DF-UHF iter   9:   -39.53295512364731   -4.24976e-11   3.74686e-08 DIIS
+   @DF-UHF iter  10:   -39.53295512364772   -4.19220e-13   5.26310e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   1.112033678E-02
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.611203368E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A1   -11.240566     2A1    -0.935251     3A1    -0.579646  
+       1B1    -0.579646     1B2    -0.386086  
+
+    Alpha Virtual:                                                        
+
+       4A1     0.196545     5A1     0.268767     2B1     0.268767  
+       3B1     0.620164     6A1     0.620164     7A1     0.644642  
+       2B2     0.672201     8A1     0.855942     9A1     0.937448  
+       4B1     0.937448     3B2     1.436603     1A2     1.436603  
+       5B1     1.749587     6B1     1.876742    10A1     1.876742  
+       4B2     2.009872    11A1     2.115982     2A2     2.527650  
+       5B2     2.527650    12A1     2.558157     7B1     2.558157  
+      13A1     3.201379    14A1     3.281707     8B1     3.281707  
+
+    Beta Occupied:                                                        
+
+       1A1   -11.215592     2A1    -0.844572     3A1    -0.564475  
+       1B1    -0.564475  
+
+    Beta Virtual:                                                         
+
+       1B2     0.141500     4A1     0.212944     5A1     0.275883  
+       2B1     0.275883     3B1     0.624722     6A1     0.624722  
+       7A1     0.687510     2B2     0.819870     8A1     0.889510  
+       9A1     0.950802     4B1     0.950802     3B2     1.487454  
+       1A2     1.487454     5B1     1.744885     6B1     1.879261  
+      10A1     1.879261     4B2     2.021879    11A1     2.198084  
+      12A1     2.562498     7B1     2.562498     2A2     2.580976  
+       5B2     2.580976    13A1     3.215399    14A1     3.293043  
+       8B1     3.293043  
+
+    Final Occupation by Irrep:
+             A1    A2    B1    B2 
+    DOCC [     3,    0,    1,    0 ]
+    SOCC [     0,    0,    0,    1 ]
+
+  @DF-UHF Final Energy:   -39.53295512364772
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.6704411415333169
+    One-Electron Energy =                 -71.4964841267355098
+    Two-Electron Energy =                  22.2930878615544685
+    Total Energy =                        -39.5329551236477243
+
+  UHF NO Occupations:
+  HONO-2 :    1 B1 1.9990580
+  HONO-1 :    3 A1 1.9963167
+  HONO-0 :    1 B2 1.0000000
+  LUNO+0 :    4 A1 0.0036833
+  LUNO+1 :    2 B1 0.0009420
+  LUNO+2 :    5 A1 0.0009420
+  LUNO+3 :    6 A1 0.0000007
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0000
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:    -0.0000     Total:     0.0000
+
+
+*** tstop() called on south at Wed Dec  1 19:33:45 2021
+Module time:
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.78 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     162.92 seconds =       2.72 minutes
+	system time =      61.78 seconds =       1.03 minutes
+	total time  =         64 seconds =       1.07 minutes
+
+  A requested method does not make use of molecular symmetry: further calculations in C1 point group.
+
+  Constructing Basis Sets for DFOCC...
+
+   => Loading Basis Set <=
+
+    Name: DEF2-UNIVERSAL-JKFIT
+    Role: JKFIT
+    Keyword: DF_BASIS_SCF
+    atoms 1   entry C          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+    atoms 2-4 entry H          line    18 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-universal-jkfit.gbs 
+
+   => Loading Basis Set <=
+
+    Name: DEF2-SVP-RI
+    Role: RIFIT
+    Keyword: DF_BASIS_CC
+    atoms 1   entry C          line   153 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+    atoms 2-4 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/def2-svp-ri.gbs 
+
+
+*** tstart() called on south
+*** at Wed Dec  1 19:33:45 2021
+
+
+
+  Module DFOCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_LAMBDA                     => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => DF              !
+  CHOLESKY                      => FALSE           !
+  CHOLESKY_TOLERANCE            => (empty)          
+  CIS_ALGORITHM                 => (empty)          
+  CI_TYPE                       => (empty)          
+  COMPUT_S2                     => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DAVIDSON_TOLERANCE            => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => DEF2-SVP-RI     !
+  DIAG_METHOD                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => FALSE           !
+  DO_SOS                        => FALSE           !
+  E3_SCALE                      => (empty)          
+  EKT_IP                        => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  HESS_TYPE                     => (empty)          
+  INTEGRAL_CUTOFF               => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  JK_MEMORY                     => (empty)          
+  JK_TYPE                       => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MOLDEN_WRITE                  => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_AMP_TYPE                  => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => DF              !
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NBO                           => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OO_SCALE                      => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PPL_TYPE                      => (empty)          
+  PRINT                         => (empty)          
+  PRINT_CI_VECS                 => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QCHF                          => (empty)          
+  QC_MODULE                     => (empty)          
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  READ_SCF_3INDEX               => (empty)          
+  REGULARIZATION                => (empty)          
+  REG_PARAM                     => (empty)          
+  RELATIVISTIC                  => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => DISK_DF         !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  TRIPLES_IABC_TYPE             => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => DF-OREMP        !
+  WRITER_FILE_LABEL             => (empty)          
+
+	For this residual convergence, default PCG convergence is:     1.00e-10
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                       DF-REMP   
+              Program Written by Ugur Bozkaya
+              Latest Revision December 8, 2020
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces... 
+
+	 FC   AOCC   BOCC  AVIR   BVIR   FV 
+	------------------------------------------
+	  1     4     3    24     25     0
+
+	Number of basis functions in the DF-CC basis:  90
+
+	Available memory                      :    500.00 MB 
+	Memory requirement for 3-index ints   :      0.94 MB 
+	Memory requirement for DF-CC int trans:      1.45 MB 
+	Memory requirement for CC contractions:      0.28 MB 
+	Total memory requirement for DF+CC int:      0.75 MB 
+	Memory requirement for Wabef term     :      0.97 MB 
+
+	Computing DF-MP2 energy ... 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	DF-HF Energy (a.u.)                :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	Scaled_SS Correlation Energy (a.u.):    -0.00797878612141
+	Scaled_OS Correlation Energy (a.u.):    -0.12279502452332
+	DF-SCS-MP2 Total Energy (a.u.)     :   -39.66372893429244
+	DF-SOS-MP2 Total Energy (a.u.)     :   -39.66598306688132
+	DF-SCSN-MP2 Total Energy (a.u.)    :   -39.57508311436874
+	DF-MP2 Correlation Energy (a.u.)   :    -0.12626554546698
+	DF-MP2 Total Energy (a.u.)         :   -39.65922066911470
+	======================================================================= 
+	Using A=        1 as REMP mixing parameter
+
+ ============================================================================== 
+ ================ Performing DF-REMP iterations... ============================= 
+ ============================================================================== 
+
+  Iter       E_corr                  DE                 T2 RMS      
+  ----   ----------------      ----------------       ----------    
+   1      -0.1262655455          0.0000000000         0.00e+00  
+
+ ============================================================================== 
+ ===================== DF-REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	======================================================================= 
+	================ REMP FINAL RESULTS =================================== 
+	======================================================================= 
+	Nuclear Repulsion Energy (a.u.)    :     9.67044114153332
+	SCF Energy (a.u.)                  :   -39.53295512364772
+	REF Energy (a.u.)                  :   -39.53295512364772
+	Alpha-Alpha Contribution (a.u.)    :    -0.01775597858935
+	Beta-Beta Contribution (a.u.)      :    -0.00618037977487
+	Alpha-Beta Contribution (a.u.)     :    -0.10232918710276
+	DF-REMP Correlation Energy (a.u.)  :    -0.12626554546698
+	DF-REMP Total Energy (a.u.)        :   -39.65922066911470
+	======================================================================= 
+
+
+*** tstop() called on south at Wed Dec  1 19:33:46 2021
+Module time:
+	user time   =       3.69 seconds =       0.06 minutes
+	system time =       1.32 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =     167.07 seconds =       2.78 minutes
+	system time =      63.18 seconds =       1.05 minutes
+	total time  =         65 seconds =       1.08 minutes
+    DF-REMP(1.00) Total Energy............................................................PASSED
+
+    Psi4 stopped on: Wednesday, 01 December 2021 07:33PM
+    Psi4 wall time for execution: 0:01:05.08
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/oremp-engrad1/CMakeLists.txt
+++ b/tests/oremp-engrad1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(oremp-engrad1 "psi;occ")

--- a/tests/oremp-engrad1/input.dat
+++ b/tests/oremp-engrad1/input.dat
@@ -1,0 +1,100 @@
+#! integral conventional OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24311146927526,  #TEST
+                     "0.10": -76.24132201209044,  #TEST
+                     "0.20": -76.23973222513877,  #TEST
+                     "0.30": -76.23831238618706,  #TEST
+                     "1.00": -76.23167599033491}  #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core false
+  wfn_type oremp
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013925124887 ],
+            [   0.000000000000,     0.003259052766,    -0.006962562443 ],  
+            [   0.000000000000,    -0.003259052766,    -0.006962562443 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013227949715 ],
+            [   0.000000000000,     0.002794520072,    -0.006613974858 ],
+            [   0.000000000000,    -0.002794520072,    -0.006613974858 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,    -0.000000000000,     0.012758472333 ],
+            [   0.000000000000,     0.002464362577,    -0.006379236166 ],
+            [   0.000000000000,    -0.002464362577,    -0.006379236166 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.012468994198 ],
+            [   0.000000000000,     0.002240361639,    -0.006234497099 ],
+            [   0.000000000000,    -0.002240361639,    -0.006234497099 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013509815917 ],
+            [   0.000000000000,     0.002462867918,    -0.006754907958 ],
+            [   0.000000000000,    -0.002462867918,    -0.006754907958 ]])
+
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST

--- a/tests/oremp-engrad1/output.ref
+++ b/tests/oremp-engrad1/output.ref
@@ -1,0 +1,2299 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 3051ec8 dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 01 December 2021 10:29AM
+
+    Process ID: 9217
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! integral conventional OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -76.24311146927526,  #TEST
+                     "0.10": -76.24132201209044,  #TEST
+                     "0.20": -76.23973222513877,  #TEST
+                     "0.30": -76.23831238618706,  #TEST
+                     "1.00": -76.23167599033491}  #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core false
+  wfn_type oremp
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013925124887 ],
+            [   0.000000000000,     0.003259052766,    -0.006962562443 ],  
+            [   0.000000000000,    -0.003259052766,    -0.006962562443 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013227949715 ],
+            [   0.000000000000,     0.002794520072,    -0.006613974858 ],
+            [   0.000000000000,    -0.002794520072,    -0.006613974858 ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,    -0.000000000000,     0.012758472333 ],
+            [   0.000000000000,     0.002464362577,    -0.006379236166 ],
+            [   0.000000000000,    -0.002464362577,    -0.006379236166 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.012468994198 ],
+            [   0.000000000000,     0.002240361639,    -0.006234497099 ],
+            [   0.000000000000,    -0.002240361639,    -0.006234497099 ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.013509815917 ],
+            [   0.000000000000,     0.002462867918,    -0.006754907958 ],
+            [   0.000000000000,    -0.002462867918,    -0.006754907958 ]])
+
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:13 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814437   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455561   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240672   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256020   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207850   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080985   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936269   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522352   -2.58608e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574698   -5.23457e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577942   -3.24434e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578034   -9.23706e-13   2.77370e-09 DIIS
+   @RHF iter  11:   -76.02676109578029    5.68434e-14   4.85672e-10 DIIS
+   @RHF iter  12:   -76.02676109578033   -4.26326e-14   2.81395e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578033
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894199032075
+    Two-Electron Energy =                  37.9234418665330679
+    Total Energy =                        -76.0267610957803299
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Wed Dec  1 10:29:13 2021
+Module time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.23 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:13 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     0     5    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578033
+	REF Energy (a.u.)                  :   -76.02676109578037
+	Alpha-Alpha Contribution (a.u.)    :    -0.02576501621985
+	Alpha-Beta Contribution (a.u.)     :    -0.15248920659062
+	Beta-Beta Contribution (a.u.)      :    -0.02576501621985
+	Scaled_SS Correlation Energy (a.u.):    -0.01717667747990
+	Scaled_OS Correlation Energy (a.u.):    -0.18298704790874
+	SCS-MP2 Total Energy (a.u.)        :   -76.22692482116902
+	SOS-MP2 Total Energy (a.u.)        :   -76.22499706434817
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11745395287427
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24771229643622
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.24024598500723
+	MP2 Correlation Energy (a.u.)      :    -0.20401923903033
+	MP2 Total Energy (a.u.)            :   -76.23078033481070
+	============================================================================== 
+
+	Using A=        0 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -76.2309483268     -1.68e-04       8.88e-04         5.46e-03        2.90e-06 
+   2     -76.2380712959     -7.12e-03       7.35e-04         3.27e-03        1.11e-06 
+   3     -76.2423470945     -4.28e-03       3.24e-04         1.43e-03        3.19e-07 
+   4     -76.2431109616     -7.64e-04       1.18e-04         5.09e-04        7.24e-08 
+   5     -76.2430996995      1.13e-05       4.90e-05         2.27e-04        3.05e-08 
+   6     -76.2431071509     -7.45e-06       1.07e-05         7.98e-05        8.71e-09 
+   7     -76.2431116069     -4.46e-06       4.21e-06         2.72e-05        2.52e-09 
+   8     -76.2431123784     -7.72e-07       1.29e-06         1.03e-05        5.19e-10 
+   9     -76.2431119793      3.99e-07       2.27e-07         1.17e-06        2.29e-10 
+  10     -76.2431115889      3.90e-07       6.01e-08         3.74e-07        6.77e-11 
+  11     -76.2431114999      8.90e-08       1.49e-08         6.28e-08        2.47e-11 
+  12     -76.2431114735      2.64e-08       5.90e-09         3.39e-08        4.88e-12 
+  13     -76.2431114697      3.81e-09       2.12e-09         1.03e-08        1.81e-12 
+  14     -76.2431114693      4.02e-10       5.42e-10         3.51e-09        4.32e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578033
+	REF Energy (a.u.)                  :   -76.02605185873141
+	Alpha-Alpha Contribution (a.u.)    :    -0.02299804796268
+	Alpha-Beta Contribution (a.u.)     :    -0.17106351429258
+	Beta-Beta Contribution (a.u.)      :    -0.02299804796268
+	OREMP Correlation Energy (a.u.)    :    -0.21635037349495
+	Eoremp - Eref (a.u.)               :    -0.21705961054387
+	OREMP Total Energy (a.u.)          :   -76.24311146927528
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 10:29:15 2021
+Module time:
+	user time   =       2.50 seconds =       0.04 minutes
+	system time =       2.52 seconds =       0.04 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       2.98 seconds =       0.05 minutes
+	system time =       2.75 seconds =       0.05 minutes
+	total time  =          2 seconds =       0.03 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000    -0.000000000000     0.013925124887
+       2       -0.000000000000     0.003259052766    -0.006962562443
+       3       -0.000000000000    -0.003259052766    -0.006962562443
+
+    OREMP(0.00) Total Energy..............................................................PASSED
+    OREMP(0.00) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:15 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455582   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240691   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256037   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207853   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936276   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522362   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23485e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577953   -3.24292e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578047   -9.37916e-13   2.77370e-09 DIIS
+   @RHF iter  11:   -76.02676109578034    1.27898e-13   4.85673e-10 DIIS
+   @RHF iter  12:   -76.02676109578032    2.84217e-14   2.81392e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578032
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894199032359
+    Two-Electron Energy =                  37.9234418665331106
+    Total Energy =                        -76.0267610957803157
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Wed Dec  1 10:29:15 2021
+Module time:
+	user time   =       0.44 seconds =       0.01 minutes
+	system time =       0.16 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       3.60 seconds =       0.06 minutes
+	system time =       3.00 seconds =       0.05 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:15 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     0     5    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02676109578036
+	Alpha-Alpha Contribution (a.u.)    :    -0.02576501621985
+	Alpha-Beta Contribution (a.u.)     :    -0.15248920659062
+	Beta-Beta Contribution (a.u.)      :    -0.02576501621985
+	Scaled_SS Correlation Energy (a.u.):    -0.01717667747990
+	Scaled_OS Correlation Energy (a.u.):    -0.18298704790874
+	SCS-MP2 Total Energy (a.u.)        :   -76.22692482116901
+	SOS-MP2 Total Energy (a.u.)        :   -76.22499706434816
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11745395287426
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24771229643619
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.24024598500722
+	MP2 Correlation Energy (a.u.)      :    -0.20401923903033
+	MP2 Total Energy (a.u.)            :   -76.23078033481069
+	============================================================================== 
+
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -76.2309445750     -1.64e-04       9.11e-04         5.59e-03        2.61e-06 
+   2     -76.2374136176     -6.47e-03       6.67e-04         2.86e-03        9.06e-07 
+   3     -76.2408403940     -3.43e-03       2.79e-04         1.24e-03        2.27e-07 
+   4     -76.2413432235     -5.03e-04       1.03e-04         4.55e-04        4.58e-08 
+   5     -76.2413197071      2.35e-05       3.96e-05         1.88e-04        1.89e-08 
+   6     -76.2413193744      3.33e-07       9.43e-06         7.22e-05        4.79e-09 
+   7     -76.2413222526     -2.88e-06       3.53e-06         2.32e-05        1.44e-09 
+   8     -76.2413226358     -3.83e-07       9.39e-07         7.35e-06        3.39e-10 
+   9     -76.2413223168      3.19e-07       1.24e-07         5.66e-07        1.37e-10 
+  10     -76.2413220697      2.47e-07       2.91e-08         1.55e-07        3.51e-11 
+  11     -76.2413220247      4.51e-08       8.08e-09         3.60e-08        1.03e-11 
+  12     -76.2413220135      1.12e-08       2.52e-09         1.29e-08        1.83e-12 
+  13     -76.2413220121      1.31e-09       8.01e-10         3.56e-09        6.10e-13 
+  14     -76.2413220121      4.72e-11       2.01e-10         1.59e-09        1.30e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02605575799696
+	Alpha-Alpha Contribution (a.u.)    :    -0.02344279342198
+	Alpha-Beta Contribution (a.u.)     :    -0.16838066714806
+	Beta-Beta Contribution (a.u.)      :    -0.02344279342198
+	OREMP Correlation Energy (a.u.)    :    -0.21456091631009
+	Eoremp - Eref (a.u.)               :    -0.21526625409345
+	OREMP Total Energy (a.u.)          :   -76.24132201209041
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 10:29:17 2021
+Module time:
+	user time   =       2.48 seconds =       0.04 minutes
+	system time =       2.58 seconds =       0.04 minutes
+	total time  =          2 seconds =       0.03 minutes
+Total time:
+	user time   =       6.08 seconds =       0.10 minutes
+	system time =       5.58 seconds =       0.09 minutes
+	total time  =          4 seconds =       0.07 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.013227949715
+       2       -0.000000000000     0.002794520072    -0.006613974858
+       3        0.000000000000    -0.002794520072    -0.006613974858
+
+    OREMP(0.10) Total Energy..............................................................PASSED
+    OREMP(0.10) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:17 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455582   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240691   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256037   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207853   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936276   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522362   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23485e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577953   -3.24292e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578047   -9.37916e-13   2.77370e-09 DIIS
+   @RHF iter  11:   -76.02676109578034    1.27898e-13   4.85673e-10 DIIS
+   @RHF iter  12:   -76.02676109578032    2.84217e-14   2.81392e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578032
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894199032359
+    Two-Electron Energy =                  37.9234418665331106
+    Total Energy =                        -76.0267610957803157
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Wed Dec  1 10:29:18 2021
+Module time:
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.65 seconds =       0.11 minutes
+	system time =       5.87 seconds =       0.10 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:18 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     0     5    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02676109578036
+	Alpha-Alpha Contribution (a.u.)    :    -0.02576501621985
+	Alpha-Beta Contribution (a.u.)     :    -0.15248920659062
+	Beta-Beta Contribution (a.u.)      :    -0.02576501621985
+	Scaled_SS Correlation Energy (a.u.):    -0.01717667747990
+	Scaled_OS Correlation Energy (a.u.):    -0.18298704790874
+	SCS-MP2 Total Energy (a.u.)        :   -76.22692482116901
+	SOS-MP2 Total Energy (a.u.)        :   -76.22499706434816
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11745395287426
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24771229643619
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.24024598500722
+	MP2 Correlation Energy (a.u.)      :    -0.20401923903033
+	MP2 Total Energy (a.u.)            :   -76.23078033481069
+	============================================================================== 
+
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -76.2309402215     -1.60e-04       9.35e-04         5.72e-03        2.33e-06 
+   2     -76.2367568996     -5.82e-03       6.03e-04         2.45e-03        7.22e-07 
+   3     -76.2394389324     -2.68e-03       2.41e-04         1.07e-03        1.57e-07 
+   4     -76.2397611046     -3.22e-04       9.05e-05         4.06e-04        2.85e-08 
+   5     -76.2397341965      2.69e-05       3.27e-05         1.54e-04        1.19e-08 
+   6     -76.2397302412      3.96e-06       8.77e-06         6.82e-05        2.95e-09 
+   7     -76.2397324359     -2.19e-06       2.90e-06         1.86e-05        1.02e-09 
+   8     -76.2397326219     -1.86e-07       6.88e-07         5.14e-06        2.23e-10 
+   9     -76.2397324178      2.04e-07       9.45e-08         4.01e-07        6.90e-11 
+  10     -76.2397322554      1.62e-07       2.23e-08         9.97e-08        1.46e-11 
+  11     -76.2397322311      2.43e-08       6.14e-09         2.87e-08        3.35e-12 
+  12     -76.2397322258      5.30e-09       1.69e-09         7.18e-09        5.65e-13 
+  13     -76.2397322251      6.21e-10       4.73e-10         2.48e-09        1.79e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02605206629708
+	Alpha-Alpha Contribution (a.u.)    :    -0.02383599354209
+	Alpha-Beta Contribution (a.u.)     :    -0.16600817180811
+	Beta-Beta Contribution (a.u.)      :    -0.02383599354209
+	OREMP Correlation Energy (a.u.)    :    -0.21297112935837
+	Eoremp - Eref (a.u.)               :    -0.21368015884160
+	OREMP Total Energy (a.u.)          :   -76.23973222513868
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 10:29:19 2021
+Module time:
+	user time   =       2.29 seconds =       0.04 minutes
+	system time =       2.47 seconds =       0.04 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.95 seconds =       0.15 minutes
+	system time =       8.34 seconds =       0.14 minutes
+	total time  =          6 seconds =       0.10 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.012758472333
+       2       -0.000000000000     0.002464362577    -0.006379236166
+       3        0.000000000000    -0.002464362577    -0.006379236166
+
+    OREMP(0.20) Total Energy..............................................................PASSED
+    OREMP(0.20) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:19 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455582   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240691   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256037   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207853   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936276   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522362   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23485e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577953   -3.24292e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578047   -9.37916e-13   2.77370e-09 DIIS
+   @RHF iter  11:   -76.02676109578034    1.27898e-13   4.85673e-10 DIIS
+   @RHF iter  12:   -76.02676109578032    2.84217e-14   2.81392e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578032
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894199032359
+    Two-Electron Energy =                  37.9234418665331106
+    Total Energy =                        -76.0267610957803157
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Wed Dec  1 10:29:20 2021
+Module time:
+	user time   =       0.42 seconds =       0.01 minutes
+	system time =       0.20 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       9.52 seconds =       0.16 minutes
+	system time =       8.65 seconds =       0.14 minutes
+	total time  =          7 seconds =       0.12 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:20 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     0     5    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02676109578036
+	Alpha-Alpha Contribution (a.u.)    :    -0.02576501621985
+	Alpha-Beta Contribution (a.u.)     :    -0.15248920659062
+	Beta-Beta Contribution (a.u.)      :    -0.02576501621985
+	Scaled_SS Correlation Energy (a.u.):    -0.01717667747990
+	Scaled_OS Correlation Energy (a.u.):    -0.18298704790874
+	SCS-MP2 Total Energy (a.u.)        :   -76.22692482116901
+	SOS-MP2 Total Energy (a.u.)        :   -76.22499706434816
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11745395287426
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24771229643619
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.24024598500722
+	MP2 Correlation Energy (a.u.)      :    -0.20401923903033
+	MP2 Total Energy (a.u.)            :   -76.23078033481069
+	============================================================================== 
+
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -76.2309352661     -1.55e-04       9.58e-04         5.85e-03        2.05e-06 
+   2     -76.2361011436     -5.17e-03       5.42e-04         2.06e-03        5.59e-07 
+   3     -76.2381432096     -2.04e-03       2.10e-04         9.17e-04        1.04e-07 
+   4     -76.2383420319     -1.99e-04       7.95e-05         3.61e-04        1.81e-08 
+   5     -76.2383158977      2.61e-05       2.77e-05         1.23e-04        8.11e-09 
+   6     -76.2383105949      5.30e-06       8.32e-06         6.57e-05        2.27e-09 
+   7     -76.2383125291     -1.93e-06       2.27e-06         1.39e-05        7.75e-10 
+   8     -76.2383126319     -1.03e-07       5.35e-07         3.72e-06        1.36e-10 
+   9     -76.2383125200      1.12e-07       7.86e-08         3.45e-07        4.41e-11 
+  10     -76.2383124052      1.15e-07       1.93e-08         8.57e-08        9.27e-12 
+  11     -76.2383123893      1.59e-08       5.11e-09         2.66e-08        2.05e-12 
+  12     -76.2383123865      2.85e-09       1.49e-09         7.01e-09        3.71e-13 
+  13     -76.2383123862      3.06e-10       4.14e-10         1.85e-09        1.30e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02604205480176
+	Alpha-Alpha Contribution (a.u.)    :    -0.02418833093501
+	Alpha-Beta Contribution (a.u.)     :    -0.16389366964960
+	Beta-Beta Contribution (a.u.)      :    -0.02418833093501
+	OREMP Correlation Energy (a.u.)    :    -0.21155129040675
+	Eoremp - Eref (a.u.)               :    -0.21227033138530
+	OREMP Total Energy (a.u.)          :   -76.23831238618706
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 10:29:21 2021
+Module time:
+	user time   =       2.46 seconds =       0.04 minutes
+	system time =       2.52 seconds =       0.04 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      11.98 seconds =       0.20 minutes
+	system time =      11.17 seconds =       0.19 minutes
+	total time  =          8 seconds =       0.13 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.012468994198
+       2       -0.000000000000     0.002240361639    -0.006234497099
+       3        0.000000000000    -0.002240361639    -0.006234497099
+
+    OREMP(0.30) Total Energy..............................................................PASSED
+    OREMP(0.30) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:22 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455582   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240691   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256037   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207853   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936276   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522362   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23485e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577953   -3.24292e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578047   -9.37916e-13   2.77370e-09 DIIS
+   @RHF iter  11:   -76.02676109578034    1.27898e-13   4.85673e-10 DIIS
+   @RHF iter  12:   -76.02676109578032    2.84217e-14   2.81392e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578032
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894199032359
+    Two-Electron Energy =                  37.9234418665331106
+    Total Energy =                        -76.0267610957803157
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Wed Dec  1 10:29:22 2021
+Module time:
+	user time   =       0.46 seconds =       0.01 minutes
+	system time =       0.18 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      12.60 seconds =       0.21 minutes
+	system time =      11.47 seconds =       0.19 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 10:29:22 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     0     5    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02676109578036
+	Alpha-Alpha Contribution (a.u.)    :    -0.02576501621985
+	Alpha-Beta Contribution (a.u.)     :    -0.15248920659062
+	Beta-Beta Contribution (a.u.)      :    -0.02576501621985
+	Scaled_SS Correlation Energy (a.u.):    -0.01717667747990
+	Scaled_OS Correlation Energy (a.u.):    -0.18298704790874
+	SCS-MP2 Total Energy (a.u.)        :   -76.22692482116901
+	SOS-MP2 Total Energy (a.u.)        :   -76.22499706434816
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11745395287426
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24771229643619
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.24024598500722
+	MP2 Correlation Energy (a.u.)      :    -0.20401923903033
+	MP2 Total Energy (a.u.)            :   -76.23078033481069
+	============================================================================== 
+
+	Using A=        1 as REMP mixing parameter
+
+	Number of independent-pairs:  95
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -76.2308837264     -1.03e-04       1.12e-03         6.75e-03        2.63e-07 
+   2     -76.2315379324     -6.54e-04       3.82e-04         1.78e-03        4.84e-08 
+   3     -76.2316557114     -1.18e-04       1.44e-04         5.57e-04        2.48e-08 
+   4     -76.2316728347     -1.71e-05       4.01e-05         3.17e-04        1.05e-08 
+   5     -76.2316763171     -3.48e-06       1.79e-05         1.47e-04        3.10e-09 
+   6     -76.2316758742      4.43e-07       2.66e-06         1.19e-05        7.21e-10 
+   7     -76.2316759802     -1.06e-07       5.23e-07         3.62e-06        5.41e-11 
+   8     -76.2316759919     -1.17e-08       9.06e-08         4.30e-07        1.03e-11 
+   9     -76.2316759902      1.71e-09       1.92e-08         7.60e-08        3.07e-12 
+  10     -76.2316759903     -1.15e-10       2.60e-09         1.13e-08        1.95e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578032
+	REF Energy (a.u.)                  :   -76.02584247510987
+	Alpha-Alpha Contribution (a.u.)    :    -0.02599959012258
+	Alpha-Beta Contribution (a.u.)     :    -0.15383433500321
+	Beta-Beta Contribution (a.u.)      :    -0.02599959012258
+	OREMP Correlation Energy (a.u.)    :    -0.20491489455458
+	Eoremp - Eref (a.u.)               :    -0.20583351522502
+	OREMP Total Energy (a.u.)          :   -76.23167599033489
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 10:29:23 2021
+Module time:
+	user time   =       1.98 seconds =       0.03 minutes
+	system time =       1.79 seconds =       0.03 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      14.58 seconds =       0.24 minutes
+	system time =      13.27 seconds =       0.22 minutes
+	total time  =         10 seconds =       0.17 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDM.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDM.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1        0.000000000000     0.000000000000     0.013509815917
+       2       -0.000000000000     0.002462867918    -0.006754907958
+       3       -0.000000000000    -0.002462867918    -0.006754907958
+
+    OREMP(1.00) Total Energy..............................................................PASSED
+    OREMP(1.00) Analytic gradients........................................................PASSED
+
+    Psi4 stopped on: Wednesday, 01 December 2021 10:29AM
+    Psi4 wall time for execution: 0:00:10.80
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/oremp-engrad2/CMakeLists.txt
+++ b/tests/oremp-engrad2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(oremp-engrad2 "psi;occ")

--- a/tests/oremp-engrad2/input.dat
+++ b/tests/oremp-engrad2/input.dat
@@ -1,0 +1,101 @@
+#! integral conventional OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+#! single point energies were independently checked using the original wavels code
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80441694409643,  #TEST
+                     "0.10": -75.80186784992698,  #TEST
+                     "0.20": -75.79955923411075,  #TEST
+                     "0.30": -75.79743802238295,  #TEST
+                     "1.00": -75.78585417924545}  #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core false
+  wfn_type oremp
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,    -0.000000000000,     0.049159038571  ],
+            [   0.000000000000,     0.041866686183,    -0.024579519285  ],  
+            [   0.000000000000,    -0.041866686183,    -0.024579519285  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.048233091249  ],
+            [   0.000000000000,     0.041344935277,    -0.024116545625  ],
+            [   0.000000000000,    -0.041344935277,    -0.024116545625  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.047576773795  ],
+            [   0.000000000000,     0.040974793680,    -0.023788386898  ],
+            [   0.000000000000,    -0.040974793680,    -0.023788386898  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.047095614965  ],
+            [   0.000000000000,     0.040703559525,    -0.023547807483  ],
+            [   0.000000000000,    -0.040703559525,    -0.023547807483  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.046028282301  ],
+            [   0.000000000000,     0.040093883348,    -0.023014141151  ],
+            [   0.000000000000,    -0.040093883348,    -0.023014141151  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST

--- a/tests/oremp-engrad2/output.ref
+++ b/tests/oremp-engrad2/output.ref
@@ -1,0 +1,2489 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} d9fa3da dirty
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Wednesday, 01 December 2021 11:24AM
+
+    Process ID: 11829
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    1
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! integral conventional OO-REMP/cc-pVDZ engrad single points for the H2O molecule.
+
+Enuc = 9.187386457589815 #TEST
+
+test_energy_dict = { "0.00": -75.80441694409643,  #TEST
+                     "0.10": -75.80186784992698,  #TEST
+                     "0.20": -75.79955923411075,  #TEST
+                     "0.30": -75.79743802238295,  #TEST
+                     "1.00": -75.78585417924545}  #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core false
+  wfn_type oremp
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+  orb_opt true
+  max_mograd_convergence 1.0E-7
+  rms_mograd_convergence 1.0E-8
+  TPDM_ABCD_TYPE direct
+
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+compare_values(Enuc, h2o.nuclear_repulsion_energy(), 8, "Nuclear Repulsion Energy") #TEST
+
+set remp_A=0.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,    -0.000000000000,     0.049159038571  ],
+            [   0.000000000000,     0.041866686183,    -0.024579519285  ],  
+            [   0.000000000000,    -0.041866686183,    -0.024579519285  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.00) Analytic gradients")  #TEST
+
+
+set remp_A=0.10
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.048233091249  ],
+            [   0.000000000000,     0.041344935277,    -0.024116545625  ],
+            [   0.000000000000,    -0.041344935277,    -0.024116545625  ]])
+
+grad_oremp=gradient('oremp')
+
+compare_values(test_energy_dict["0.10"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.10) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.10) Analytic gradients")  #TEST
+
+
+set remp_A=0.20
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.047576773795  ],
+            [   0.000000000000,     0.040974793680,    -0.023788386898  ],
+            [   0.000000000000,    -0.040974793680,    -0.023788386898  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.20"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.20) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.20) Analytic gradients")  #TEST
+
+set remp_A=0.30
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.047095614965  ],
+            [   0.000000000000,     0.040703559525,    -0.023547807483  ],
+            [   0.000000000000,    -0.040703559525,    -0.023547807483  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["0.30"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(0.30) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(0.30) Analytic gradients")  #TEST
+
+set remp_A=1.00
+ref_grad=psi4.Matrix.from_list([
+            [   0.000000000000,     0.000000000000,     0.046028282301  ],
+            [   0.000000000000,     0.040093883348,    -0.023014141151  ],
+            [   0.000000000000,    -0.040093883348,    -0.023014141151  ]])
+
+grad_oremp=gradient('oremp')
+compare_values(test_energy_dict["1.00"], variable("OREMP TOTAL ENERGY"), 8, "OREMP(1.00) Total Energy") #TEST
+compare_matrices(ref_grad, grad_oremp, 5, "OREMP(1.00) Analytic gradients")  #TEST
+--------------------------------------------------------------------------
+    Nuclear Repulsion Energy..............................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:33 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814437   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757597   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039659   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127694   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068536   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929180   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485055   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373717   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376484   -5.00277e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462481   -8.59970e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466292   -3.81135e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466394   -1.02318e-12   7.40709e-09 DIIS
+   @UHF iter  12:   -75.63189745466394    0.00000e+00   1.99032e-09 DIIS
+   @UHF iter  13:   -75.63189745466396   -1.42109e-14   2.15109e-10 DIIS
+   @UHF iter  14:   -75.63189745466401   -5.68434e-14   3.96041e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087273197E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466401
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596542824034998
+    Two-Electron Energy =                  33.2403703701496767
+    Total Energy =                        -75.6318974546640135
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Wed Dec  1 11:24:33 2021
+Module time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:33 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     0     5     4    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466401
+	REF Energy (a.u.)                  :   -75.63189745466400
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444291296420
+	Alpha-Beta Contribution (a.u.)     :    -0.11738905383617
+	Beta-Beta Contribution (a.u.)      :    -0.01140565460778
+	Scaled_SS Correlation Energy (a.u.):    -0.01194952252399
+	Scaled_OS Correlation Energy (a.u.):    -0.14086686460340
+	SCS-MP2 Total Energy (a.u.)        :   -75.78471384179139
+	SOS-MP2 Total Energy (a.u.)        :   -75.78450322465102
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69499093359067
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.80007972736028
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79624213003464
+	MP2 Correlation Energy (a.u.)      :    -0.15323762140814
+	MP2 Total Energy (a.u.)            :   -75.78513507607214
+	============================================================================== 
+
+	Using A=        0 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -75.7852546016     -1.20e-04       1.72e-03         8.14e-03        3.60e-06 
+   2     -75.7993967448     -1.41e-02       1.08e-03         5.80e-03        1.39e-06 
+   3     -75.8030816065     -3.68e-03       6.47e-04         2.88e-03        6.32e-07 
+   4     -75.8044308332     -1.35e-03       2.64e-04         1.08e-03        2.90e-07 
+   5     -75.8043094915      1.21e-04       9.07e-05         3.77e-04        1.75e-07 
+   6     -75.8043951710     -8.57e-05       2.96e-05         1.47e-04        5.59e-08 
+   7     -75.8044157330     -2.06e-05       1.02e-05         6.74e-05        1.68e-08 
+   8     -75.8044179376     -2.20e-06       3.35e-06         1.96e-05        6.26e-09 
+   9     -75.8044167234      1.21e-06       1.17e-06         8.42e-06        2.70e-09 
+  10     -75.8044170527     -3.29e-07       5.03e-07         4.01e-06        9.34e-10 
+  11     -75.8044170284      2.43e-08       1.37e-07         8.51e-07        2.77e-10 
+  12     -75.8044169388      8.96e-08       4.08e-08         1.86e-07        6.24e-11 
+  13     -75.8044169273      1.15e-08       1.55e-08         6.22e-08        2.24e-11 
+  14     -75.8044169351     -7.86e-09       6.94e-09         3.04e-08        9.17e-12 
+  15     -75.8044169404     -5.31e-09       2.69e-09         1.35e-08        4.75e-12 
+  16     -75.8044169432     -2.78e-09       1.05e-09         5.14e-09        2.13e-12 
+  17     -75.8044169441     -8.64e-10       3.63e-10         1.63e-09        6.92e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466401
+	REF Energy (a.u.)                  :   -75.63112702139408
+	Alpha-Alpha Contribution (a.u.)    :    -0.02384160221579
+	Alpha-Beta Contribution (a.u.)     :    -0.13866839967314
+	Beta-Beta Contribution (a.u.)      :    -0.01077992080553
+	OREMP Correlation Energy (a.u.)    :    -0.17251948943242
+	Eoremp - Eref (a.u.)               :    -0.17328992270235
+	OREMP Total Energy (a.u.)          :   -75.80441694409643
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 11:24:37 2021
+Module time:
+	user time   =       4.47 seconds =       0.07 minutes
+	system time =       4.11 seconds =       0.07 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =       4.95 seconds =       0.08 minutes
+	system time =       4.39 seconds =       0.07 minutes
+	total time  =          4 seconds =       0.07 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDMs.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Sorting File: MO TPDM (AA|aa) nbuckets = 1
+	Sorting File: MO TPDM (aa|aa) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDMs.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000    -0.000000000000     0.049159038571
+       2        0.000000000000     0.041866686183    -0.024579519285
+       3        0.000000000000    -0.041866686183    -0.024579519285
+
+    OREMP(0.00) Total Energy..............................................................PASSED
+    OREMP(0.00) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:38 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757614   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039662   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127701   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929187   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485060   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373731   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00276e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462489   -8.59941e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466295   -3.80567e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466408   -1.13687e-12   7.40709e-09 DIIS
+   @UHF iter  12:   -75.63189745466403    5.68434e-14   1.99032e-09 DIIS
+   @UHF iter  13:   -75.63189745466406   -2.84217e-14   2.15109e-10 DIIS
+   @UHF iter  14:   -75.63189745466407   -1.42109e-14   3.96038e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087273197E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466407
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596542824034714
+    Two-Electron Energy =                  33.2403703701495985
+    Total Energy =                        -75.6318974546640561
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Wed Dec  1 11:24:38 2021
+Module time:
+	user time   =       0.52 seconds =       0.01 minutes
+	system time =       0.31 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.62 seconds =       0.09 minutes
+	system time =       4.78 seconds =       0.08 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:38 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     0     5     4    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444291296420
+	Alpha-Beta Contribution (a.u.)     :    -0.11738905383617
+	Beta-Beta Contribution (a.u.)      :    -0.01140565460778
+	Scaled_SS Correlation Energy (a.u.):    -0.01194952252399
+	Scaled_OS Correlation Energy (a.u.):    -0.14086686460340
+	SCS-MP2 Total Energy (a.u.)        :   -75.78471384179143
+	SOS-MP2 Total Energy (a.u.)        :   -75.78450322465106
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69499093359072
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.80007972736033
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79624213003467
+	MP2 Correlation Energy (a.u.)      :    -0.15323762140814
+	MP2 Total Energy (a.u.)            :   -75.78513507607218
+	============================================================================== 
+
+	Using A=      0.1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -75.7852522243     -1.17e-04       1.74e-03         8.23e-03        3.25e-06 
+   2     -75.7980298412     -1.28e-02       1.02e-03         5.44e-03        1.13e-06 
+   3     -75.8009825272     -2.95e-03       6.06e-04         2.62e-03        4.58e-07 
+   4     -75.8019720733     -9.90e-04       2.28e-04         9.21e-04        1.76e-07 
+   5     -75.8018254895      1.47e-04       8.18e-05         3.15e-04        9.38e-08 
+   6     -75.8018625530     -3.71e-05       2.28e-05         1.10e-04        2.11e-08 
+   7     -75.8018696320     -7.08e-06       7.23e-06         4.53e-05        5.41e-09 
+   8     -75.8018690741      5.58e-07       2.17e-06         1.43e-05        1.89e-09 
+   9     -75.8018678787      1.20e-06       6.65e-07         4.20e-06        6.97e-10 
+  10     -75.8018678748      3.81e-09       1.88e-07         1.40e-06        2.08e-10 
+  11     -75.8018678754     -5.91e-10       5.53e-08         3.29e-07        5.51e-11 
+  12     -75.8018678538      2.16e-08       1.26e-08         7.17e-08        1.13e-11 
+  13     -75.8018678495      4.30e-09       4.81e-09         2.16e-08        4.15e-12 
+  14     -75.8018678499     -3.83e-10       1.59e-09         9.40e-09        2.02e-12 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63115308205502
+	Alpha-Alpha Contribution (a.u.)    :    -0.02401801544837
+	Alpha-Beta Contribution (a.u.)     :    -0.13577300364202
+	Beta-Beta Contribution (a.u.)      :    -0.01092374954885
+	OREMP Correlation Energy (a.u.)    :    -0.16997039526291
+	Eoremp - Eref (a.u.)               :    -0.17071476787196
+	OREMP Total Energy (a.u.)          :   -75.80186784992698
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 11:24:42 2021
+Module time:
+	user time   =       4.06 seconds =       0.07 minutes
+	system time =       3.16 seconds =       0.05 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =       9.68 seconds =       0.16 minutes
+	system time =       7.94 seconds =       0.13 minutes
+	total time  =          9 seconds =       0.15 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDMs.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Sorting File: MO TPDM (AA|aa) nbuckets = 1
+	Sorting File: MO TPDM (aa|aa) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDMs.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.048233091249
+       2        0.000000000000     0.041344935277    -0.024116545625
+       3        0.000000000000    -0.041344935277    -0.024116545625
+
+    OREMP(0.10) Total Energy..............................................................PASSED
+    OREMP(0.10) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:42 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757614   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039662   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127701   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929187   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485060   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373731   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00276e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462489   -8.59941e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466295   -3.80567e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466408   -1.13687e-12   7.40709e-09 DIIS
+   @UHF iter  12:   -75.63189745466403    5.68434e-14   1.99032e-09 DIIS
+   @UHF iter  13:   -75.63189745466406   -2.84217e-14   2.15109e-10 DIIS
+   @UHF iter  14:   -75.63189745466407   -1.42109e-14   3.96038e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087273197E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466407
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596542824034714
+    Two-Electron Energy =                  33.2403703701495985
+    Total Energy =                        -75.6318974546640561
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Wed Dec  1 11:24:42 2021
+Module time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.29 seconds =       0.17 minutes
+	system time =       8.22 seconds =       0.14 minutes
+	total time  =          9 seconds =       0.15 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:42 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     0     5     4    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444291296420
+	Alpha-Beta Contribution (a.u.)     :    -0.11738905383617
+	Beta-Beta Contribution (a.u.)      :    -0.01140565460778
+	Scaled_SS Correlation Energy (a.u.):    -0.01194952252399
+	Scaled_OS Correlation Energy (a.u.):    -0.14086686460340
+	SCS-MP2 Total Energy (a.u.)        :   -75.78471384179143
+	SOS-MP2 Total Energy (a.u.)        :   -75.78450322465106
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69499093359072
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.80007972736033
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79624213003467
+	MP2 Correlation Energy (a.u.)      :    -0.15323762140814
+	MP2 Total Energy (a.u.)            :   -75.78513507607218
+	============================================================================== 
+
+	Using A=      0.2 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -75.7852496098     -1.15e-04       1.77e-03         8.33e-03        2.90e-06 
+   2     -75.7966632090     -1.14e-02       9.71e-04         5.07e-03        8.99e-07 
+   3     -75.7989722318     -2.31e-03       5.70e-04         2.39e-03        3.23e-07 
+   4     -75.7996931999     -7.21e-04       1.98e-04         7.86e-04        1.03e-07 
+   5     -75.7995436513      1.50e-04       7.52e-05         2.93e-04        4.59e-08 
+   6     -75.7995586915     -1.50e-05       1.85e-05         8.80e-05        6.64e-09 
+   7     -75.7995614650     -2.77e-06       5.36e-06         3.26e-05        2.37e-09 
+   8     -75.7995602471      1.22e-06       1.47e-06         9.98e-06        1.02e-09 
+   9     -75.7995592752      9.72e-07       4.00e-07         2.53e-06        2.82e-10 
+  10     -75.7995592329      4.22e-08       1.01e-07         4.38e-07        6.35e-11 
+  11     -75.7995592398     -6.82e-09       2.26e-08         8.66e-08        1.09e-11 
+  12     -75.7995592354      4.39e-09       5.90e-09         3.49e-08        2.45e-12 
+  13     -75.7995592342      1.19e-09       1.88e-09         8.64e-09        1.03e-12 
+  14     -75.7995592341      6.90e-11       4.72e-10         2.88e-09        4.61e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63117034374125
+	Alpha-Alpha Contribution (a.u.)    :    -0.02416194230128
+	Alpha-Beta Contribution (a.u.)     :    -0.13318274716056
+	Beta-Beta Contribution (a.u.)      :    -0.01104420099514
+	OREMP Correlation Energy (a.u.)    :    -0.16766177944668
+	Eoremp - Eref (a.u.)               :    -0.16838889036950
+	OREMP Total Energy (a.u.)          :   -75.79955923411075
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 11:24:46 2021
+Module time:
+	user time   =       3.85 seconds =       0.06 minutes
+	system time =       3.32 seconds =       0.06 minutes
+	total time  =          4 seconds =       0.07 minutes
+Total time:
+	user time   =      14.14 seconds =       0.24 minutes
+	system time =      11.55 seconds =       0.19 minutes
+	total time  =         13 seconds =       0.22 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDMs.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Sorting File: MO TPDM (AA|aa) nbuckets = 1
+	Sorting File: MO TPDM (aa|aa) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDMs.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.047576773795
+       2        0.000000000000     0.040974793680    -0.023788386898
+       3        0.000000000000    -0.040974793680    -0.023788386898
+
+    OREMP(0.20) Total Energy..............................................................PASSED
+    OREMP(0.20) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:46 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757614   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039662   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127701   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929187   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485060   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373731   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00276e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462489   -8.59941e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466295   -3.80567e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466408   -1.13687e-12   7.40709e-09 DIIS
+   @UHF iter  12:   -75.63189745466403    5.68434e-14   1.99032e-09 DIIS
+   @UHF iter  13:   -75.63189745466406   -2.84217e-14   2.15109e-10 DIIS
+   @UHF iter  14:   -75.63189745466407   -1.42109e-14   3.96038e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087273197E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466407
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596542824034714
+    Two-Electron Energy =                  33.2403703701495985
+    Total Energy =                        -75.6318974546640561
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Wed Dec  1 11:24:46 2021
+Module time:
+	user time   =       0.51 seconds =       0.01 minutes
+	system time =       0.22 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      14.79 seconds =       0.25 minutes
+	system time =      11.85 seconds =       0.20 minutes
+	total time  =         13 seconds =       0.22 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:46 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     0     5     4    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444291296420
+	Alpha-Beta Contribution (a.u.)     :    -0.11738905383617
+	Beta-Beta Contribution (a.u.)      :    -0.01140565460778
+	Scaled_SS Correlation Energy (a.u.):    -0.01194952252399
+	Scaled_OS Correlation Energy (a.u.):    -0.14086686460340
+	SCS-MP2 Total Energy (a.u.)        :   -75.78471384179143
+	SOS-MP2 Total Energy (a.u.)        :   -75.78450322465106
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69499093359072
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.80007972736033
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79624213003467
+	MP2 Correlation Energy (a.u.)      :    -0.15323762140814
+	MP2 Total Energy (a.u.)            :   -75.78513507607218
+	============================================================================== 
+
+	Using A=      0.3 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -75.7852467579     -1.12e-04       1.79e-03         8.42e-03        2.55e-06 
+   2     -75.7952968488     -1.01e-02       9.21e-04         4.68e-03        6.95e-07 
+   3     -75.7970511519     -1.75e-03       5.38e-04         2.17e-03        2.20e-07 
+   4     -75.7975726776     -5.22e-04       1.73e-04         6.68e-04        5.89e-08 
+   5     -75.7974323369      1.40e-04       6.95e-05         2.75e-04        1.99e-08 
+   6     -75.7974380422     -5.71e-06       1.52e-05         7.23e-05        4.62e-09 
+   7     -75.7974397181     -1.68e-06       4.07e-06         2.55e-05        1.83e-09 
+   8     -75.7974386630      1.06e-06       1.14e-06         7.97e-06        5.41e-10 
+   9     -75.7974380428      6.20e-07       3.24e-07         2.08e-06        7.96e-11 
+  10     -75.7974379991      4.37e-08       8.21e-08         3.33e-07        2.36e-11 
+  11     -75.7974380176     -1.85e-08       1.49e-08         6.59e-08        7.43e-12 
+  12     -75.7974380218     -4.22e-09       2.87e-09         1.39e-08        2.94e-12 
+  13     -75.7974380224     -5.58e-10       1.00e-09         5.54e-09        1.07e-12 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63118160361738
+	Alpha-Alpha Contribution (a.u.)    :    -0.02427886918849
+	Alpha-Beta Contribution (a.u.)     :    -0.13083223331645
+	Beta-Beta Contribution (a.u.)      :    -0.01114531642079
+	OREMP Correlation Energy (a.u.)    :    -0.16554056771888
+	Eoremp - Eref (a.u.)               :    -0.16625641876557
+	OREMP Total Energy (a.u.)          :   -75.79743802238295
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 11:24:49 2021
+Module time:
+	user time   =       3.45 seconds =       0.06 minutes
+	system time =       3.28 seconds =       0.05 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      18.24 seconds =       0.30 minutes
+	system time =      15.14 seconds =       0.25 minutes
+	total time  =         16 seconds =       0.27 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDMs.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Sorting File: MO TPDM (AA|aa) nbuckets = 1
+	Sorting File: MO TPDM (aa|aa) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDMs.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.047095614965
+       2        0.000000000000     0.040703559525    -0.023547807483
+       3        0.000000000000    -0.040703559525    -0.023547807483
+
+    OREMP(0.30) Total Energy..............................................................PASSED
+    OREMP(0.30) Analytic gradients........................................................PASSED
+
+Scratch directory: /scr/behnle/
+gradient() will perform analytic gradient computation.
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:50 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        1 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-10
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814440   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757614   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039662   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127701   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929187   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485060   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373731   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00276e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462489   -8.59941e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466295   -3.80567e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466408   -1.13687e-12   7.40709e-09 DIIS
+   @UHF iter  12:   -75.63189745466403    5.68434e-14   1.99032e-09 DIIS
+   @UHF iter  13:   -75.63189745466406   -2.84217e-14   2.15109e-10 DIIS
+   @UHF iter  14:   -75.63189745466407   -1.42109e-14   3.96038e-11 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087273197E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872732E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466407
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596542824034714
+    Two-Electron Energy =                  33.2403703701495985
+    Total Energy =                        -75.6318974546640561
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Wed Dec  1 11:24:50 2021
+Module time:
+	user time   =       0.43 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      18.82 seconds =       0.31 minutes
+	system time =      15.50 seconds =       0.26 minutes
+	total time  =         17 seconds =       0.28 minutes
+
+*** tstart() called on south
+*** at Wed Dec  1 11:24:50 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => FIRST           !
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => FALSE           !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => 1e-07           !
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => TRUE            !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => 1e-08           !
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => DIRECT          !
+  WFN                           => (empty)          
+  WFN_TYPE                      => OREMP           !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                           OO-REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     0     5     4    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02444291296420
+	Alpha-Beta Contribution (a.u.)     :    -0.11738905383617
+	Beta-Beta Contribution (a.u.)      :    -0.01140565460778
+	Scaled_SS Correlation Energy (a.u.):    -0.01194952252399
+	Scaled_OS Correlation Energy (a.u.):    -0.14086686460340
+	SCS-MP2 Total Energy (a.u.)        :   -75.78471384179143
+	SOS-MP2 Total Energy (a.u.)        :   -75.78450322465106
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69499093359072
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.80007972736033
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79624213003467
+	MP2 Correlation Energy (a.u.)      :    -0.15323762140814
+	MP2 Total Energy (a.u.)            :   -75.78513507607218
+	============================================================================== 
+
+	Using A=        1 as REMP mixing parameter
+
+	Number of alpha independent-pairs: 95
+	Number of beta independent-pairs : 80
+
+ ============================================================================== 
+ ================ Performing OREMP iterations... ============================= 
+ ============================================================================== 
+	            Minimizing REMP-L Functional 
+	            --------------------------- 
+ Iter       E_total           DE           RMS MO Grad      MAX MO Grad      RMS T2    
+ ----    ---------------    ----------     -----------      -----------     ---------- 
+   1     -75.7852201509     -8.51e-05       1.96e-03         9.07e-03        2.50e-07 
+   2     -75.7857399941     -5.20e-04       6.61e-04         3.71e-03        4.45e-08 
+   3     -75.7858011721     -6.12e-05       4.00e-04         1.39e-03        3.03e-08 
+   4     -75.7858562801     -5.51e-05       8.39e-05         3.65e-04        6.78e-09 
+   5     -75.7858549572      1.32e-06       1.55e-05         7.27e-05        2.43e-09 
+   6     -75.7858540370      9.20e-07       6.45e-06         4.01e-05        6.95e-10 
+   7     -75.7858542057     -1.69e-07       1.23e-06         8.56e-06        2.84e-10 
+   8     -75.7858541833      2.24e-08       5.38e-07         3.98e-06        8.32e-11 
+   9     -75.7858541759      7.45e-09       7.86e-08         4.35e-07        1.21e-11 
+  10     -75.7858541799     -4.08e-09       2.15e-08         9.95e-08        3.36e-12 
+  11     -75.7858541792      6.89e-10       6.90e-09         3.76e-08        8.57e-13 
+
+ ============================================================================== 
+ ======================== OREMP ITERATIONS ARE CONVERGED ====================== 
+ ============================================================================== 
+
+	============================================================================== 
+	================ OREMP FINAL RESULTS ============================== 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466407
+	REF Energy (a.u.)                  :   -75.63117617572260
+	Alpha-Alpha Contribution (a.u.)    :    -0.02462751719418
+	Alpha-Beta Contribution (a.u.)     :    -0.11852981049395
+	Beta-Beta Contribution (a.u.)      :    -0.01152067576272
+	OREMP Correlation Energy (a.u.)    :    -0.15395672458138
+	Eoremp - Eref (a.u.)               :    -0.15467800352285
+	OREMP Total Energy (a.u.)          :   -75.78585417924545
+	============================================================================== 
+
+	Analytic gradient computation is starting...
+	Computing G_abcd...
+	Computing diagonal blocks of GFM...
+	Writing particle density matrices and GFM to disk...
+	Necessary information has been sent to DERIV, which will take care of the rest.
+
+*** tstop() called on south at Wed Dec  1 11:24:53 2021
+Module time:
+	user time   =       3.00 seconds =       0.05 minutes
+	system time =       2.72 seconds =       0.05 minutes
+	total time  =          3 seconds =       0.05 minutes
+Total time:
+	user time   =      21.83 seconds =       0.36 minutes
+	system time =      18.22 seconds =       0.30 minutes
+	total time  =         20 seconds =       0.33 minutes
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Bohr), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z       
+    ------------   -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.124070173015
+         H            0.000000000000    -1.431214220689     0.984541840469
+         H            0.000000000000     1.431214220689     0.984541840469
+
+	Presorting MO-basis TPDMs.
+	Sorting File: MO TPDM (AA|AA) nbuckets = 1
+	Sorting File: MO TPDM (AA|aa) nbuckets = 1
+	Sorting File: MO TPDM (aa|aa) nbuckets = 1
+	Starting first half-transformation.
+	Sorting half-transformed TPDMs.
+	First half integral transformation complete.
+
+
+  -Total gradient:
+     Atom            X                  Y                   Z
+    ------   -----------------  -----------------  -----------------
+       1       -0.000000000000     0.000000000000     0.046028282301
+       2        0.000000000000     0.040093883348    -0.023014141151
+       3        0.000000000000    -0.040093883348    -0.023014141151
+
+    OREMP(1.00) Total Energy..............................................................PASSED
+    OREMP(1.00) Analytic gradients........................................................PASSED
+
+    Psi4 stopped on: Wednesday, 01 December 2021 11:24AM
+    Psi4 wall time for execution: 0:00:19.94
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/remp-energy1/CMakeLists.txt
+++ b/tests/remp-energy1/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(remp-energy1 "psi;occ")

--- a/tests/remp-energy1/input.dat
+++ b/tests/remp-energy1/input.dat
@@ -1,0 +1,58 @@
+#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+
+test_dict = { "0.00": -76.24029833889607,  #TEST
+              "0.10": -76.23848960921946,  #TEST
+              "0.20": -76.23687362533647,  #TEST
+              "0.30": -76.23542183078382,  #TEST
+              "1.00": -76.22844321801395 } #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core true
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(1.00) Total Energy") #TEST
+

--- a/tests/remp-energy1/input.dat
+++ b/tests/remp-energy1/input.dat
@@ -1,4 +1,5 @@
 #! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+#! results were independently verified against the initial wavels implementation
 
 test_dict = { "0.00": -76.24029833889607,  #TEST
               "0.10": -76.23848960921946,  #TEST

--- a/tests/remp-energy1/output.ref
+++ b/tests/remp-energy1/output.ref
@@ -1,0 +1,2060 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 081ae72 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 30 November 2021 08:34AM
+
+    Process ID: 5538
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! integral conventional REMP/cc-pVDZ energies for the H2O molecule.
+
+#ref = psi4.Matrix.from_list([                                            #TEST
+#        [  0.000000000000,    -0.00000000004556,     0.01125855952669],  #TEST
+#       [  0.000000000000,     0.00201761388675,    -0.00562927978099],  #TEST
+#        [  0.000000000000,    -0.00201761384119,    -0.00562927974570]   #TEST
+#      ])                                                                 #TEST
+
+test_dict = { "0.00": -76.24029833889607,  #TEST
+              "0.10": -76.23848960921946,  #TEST
+              "0.20": -76.23687362533647,  #TEST
+              "0.30": -76.23542183078382,  #TEST
+              "1.00": -76.22844321801395 } #TEST
+
+molecule h2o {
+0 1
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  basis cc-pvdz
+#  df_basis_scf cc-pvdz-jkfit
+#  df_basis_cc cc-pvdz-ri
+  guess sad
+  scf_type out_of_core
+  freeze_core true
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(1.00) Total Energy") #TEST
+
+
+#compare_matrices(ref, grad, 5, "Analytic gradients")  #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:43 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814443   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455568   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240678   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256024   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207847   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080982   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936272   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522345   -2.58607e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574702   -5.23571e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577948   -3.24576e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578027   -7.95808e-13   2.77370e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578027
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894771224466
+    Two-Electron Energy =                  37.9234419237523710
+    Total Energy =                        -76.0267610957802731
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Tue Nov 30 08:34:44 2021
+Module time:
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       0.74 seconds =       0.01 minutes
+	system time =       0.21 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:44 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     1     4    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578027
+	REF Energy (a.u.)                  :   -76.02676109578027
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858626
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	Scaled_SS Correlation Energy (a.u.):    -0.01690652121575
+	Scaled_OS Correlation Energy (a.u.):    -0.18115507030352
+	SCS-MP2 Total Energy (a.u.)        :   -76.22482268729955
+	SOS-MP2 Total Energy (a.u.)        :   -76.22301242194241
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11602752779945
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24535295259432
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.23810867780104
+	MP2 Correlation Energy (a.u.)      :    -0.20168212223352
+	MP2 Total Energy (a.u.)            :   -76.22844321801379
+	============================================================================== 
+
+	Using A=        0 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1509625586    -76.1777236544      5.07e-02     3.35e-05 
+   2     -0.2123915208    -76.2391526166     -6.14e-02     4.47e-06 
+   3     -0.2130563389    -76.2398174347     -6.65e-04     1.56e-06 
+   4     -0.2136180836    -76.2403791794     -5.62e-04     3.67e-07 
+   5     -0.2135407173    -76.2403018131      7.74e-05     6.80e-08 
+   6     -0.2135370632    -76.2402981589      3.65e-06     1.67e-08 
+   7     -0.2135378170    -76.2402989128     -7.54e-07     3.90e-09 
+   8     -0.2135372942    -76.2402983900      5.23e-07     1.07e-09 
+   9     -0.2135372211    -76.2402983169      7.31e-08     1.80e-10 
+  10     -0.2135372357    -76.2402983315     -1.46e-08     3.13e-11 
+  11     -0.2135372421    -76.2402983379     -6.41e-09     8.21e-12 
+  12     -0.2135372430    -76.2402983388     -8.67e-10     1.75e-12 
+  13     -0.2135372431    -76.2402983389     -1.19e-10     3.90e-13 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578027
+	REF Energy (a.u.)                  :   -76.02676109578027
+	Alpha-Alpha Contribution (a.u.)    :    -0.02257701749807
+	Alpha-Beta Contribution (a.u.)     :    -0.16838320811963
+	Beta-Beta Contribution (a.u.)      :    -0.02257701749807
+	REMP Correlation Energy (a.u.)     :    -0.21353724311578
+	REMP Total Energy (a.u.)           :   -76.24029833889605
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 08:34:44 2021
+Module time:
+	user time   =       0.40 seconds =       0.01 minutes
+	system time =       0.38 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.15 seconds =       0.02 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+    REMP(0.00) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:44 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814439   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455576   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240686   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256033   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207856   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080991   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936279   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522366   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23443e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577953   -3.24292e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578044   -9.09495e-13   2.77370e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578044
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894771225319
+    Two-Electron Energy =                  37.9234419237522715
+    Total Energy =                        -76.0267610957804436
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Tue Nov 30 08:34:44 2021
+Module time:
+	user time   =       0.66 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       1.85 seconds =       0.03 minutes
+	system time =       0.88 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:44 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     1     4    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578044
+	REF Energy (a.u.)                  :   -76.02676109578044
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858626
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	Scaled_SS Correlation Energy (a.u.):    -0.01690652121575
+	Scaled_OS Correlation Energy (a.u.):    -0.18115507030352
+	SCS-MP2 Total Energy (a.u.)        :   -76.22482268729972
+	SOS-MP2 Total Energy (a.u.)        :   -76.22301242194258
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11602752779962
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24535295259449
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.23810867780121
+	MP2 Correlation Energy (a.u.)      :    -0.20168212223352
+	MP2 Total Energy (a.u.)            :   -76.22844321801396
+	============================================================================== 
+
+	Using A=      0.1 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.2117951782    -76.2385562740     -1.01e-02     7.01e-07 
+   2     -0.2117477184    -76.2385088142      4.75e-05     2.58e-07 
+   3     -0.2117109101    -76.2384720059      3.68e-05     3.39e-08 
+   4     -0.2117276960    -76.2384887918     -1.68e-05     8.64e-09 
+   5     -0.2117285423    -76.2384896381     -8.46e-07     1.53e-09 
+   6     -0.2117284757    -76.2384895714      6.66e-08     2.78e-10 
+   7     -0.2117285128    -76.2384896086     -3.72e-08     6.46e-11 
+   8     -0.2117285135    -76.2384896092     -6.50e-10     1.02e-11 
+   9     -0.2117285134    -76.2384896092      1.96e-11     2.01e-12 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578044
+	REF Energy (a.u.)                  :   -76.02676109578044
+	Alpha-Alpha Contribution (a.u.)    :    -0.02299895997247
+	Alpha-Beta Contribution (a.u.)     :    -0.16573059349410
+	Beta-Beta Contribution (a.u.)      :    -0.02299895997247
+	REMP Correlation Energy (a.u.)     :    -0.21172851343904
+	REMP Total Energy (a.u.)           :   -76.23848960921949
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 08:34:45 2021
+Module time:
+	user time   =       0.41 seconds =       0.01 minutes
+	system time =       0.29 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       2.26 seconds =       0.04 minutes
+	system time =       1.17 seconds =       0.02 minutes
+	total time  =          2 seconds =       0.03 minutes
+    REMP(0.10) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:45 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814442   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455575   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240686   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256036   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207851   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936276   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522363   -2.58609e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574708   -5.23443e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577952   -3.24434e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578042   -8.95284e-13   2.77370e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578042
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894771224893
+    Two-Electron Energy =                  37.9234419237522715
+    Total Energy =                        -76.0267610957804152
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Tue Nov 30 08:34:46 2021
+Module time:
+	user time   =       2.08 seconds =       0.03 minutes
+	system time =       0.47 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       4.36 seconds =       0.07 minutes
+	system time =       1.65 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:46 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     1     4    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578042
+	REF Energy (a.u.)                  :   -76.02676109578042
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858627
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	Scaled_SS Correlation Energy (a.u.):    -0.01690652121575
+	Scaled_OS Correlation Energy (a.u.):    -0.18115507030352
+	SCS-MP2 Total Energy (a.u.)        :   -76.22482268729969
+	SOS-MP2 Total Energy (a.u.)        :   -76.22301242194256
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11602752779959
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24535295259446
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.23810867780119
+	MP2 Correlation Energy (a.u.)      :    -0.20168212223352
+	MP2 Total Energy (a.u.)            :   -76.22844321801394
+	============================================================================== 
+
+	Using A=      0.2 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.2100876203    -76.2368487161     -8.41e-03     6.59e-07 
+   2     -0.2101056226    -76.2368667184     -1.80e-05     2.13e-07 
+   3     -0.2100982641    -76.2368593598      7.36e-06     2.38e-08 
+   4     -0.2101118173    -76.2368729131     -1.36e-05     5.33e-09 
+   5     -0.2101125456    -76.2368736414     -7.28e-07     8.04e-10 
+   6     -0.2101125116    -76.2368736074      3.40e-08     1.25e-10 
+   7     -0.2101125288    -76.2368736246     -1.72e-08     2.55e-11 
+   8     -0.2101125296    -76.2368736254     -8.39e-10     3.51e-12 
+   9     -0.2101125296    -76.2368736253      8.71e-11     5.99e-13 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578042
+	REF Energy (a.u.)                  :   -76.02676109578042
+	Alpha-Alpha Contribution (a.u.)    :    -0.02337033883321
+	Alpha-Beta Contribution (a.u.)     :    -0.16337185188959
+	Beta-Beta Contribution (a.u.)      :    -0.02337033883321
+	REMP Correlation Energy (a.u.)     :    -0.21011252955600
+	REMP Total Energy (a.u.)           :   -76.23687362533641
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 08:34:46 2021
+Module time:
+	user time   =       0.38 seconds =       0.01 minutes
+	system time =       0.28 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.75 seconds =       0.08 minutes
+	system time =       1.93 seconds =       0.03 minutes
+	total time  =          3 seconds =       0.05 minutes
+    REMP(0.20) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:46 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814442   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455575   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240682   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256036   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207851   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080988   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936273   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522358   -2.58608e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574715   -5.23571e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577948   -3.23297e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578043   -9.52127e-13   2.77370e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578043
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894771224893
+    Two-Electron Energy =                  37.9234419237522502
+    Total Energy =                        -76.0267610957804294
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Tue Nov 30 08:34:46 2021
+Module time:
+	user time   =       0.70 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       5.48 seconds =       0.09 minutes
+	system time =       2.21 seconds =       0.04 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:46 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     1     4    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578043
+	REF Energy (a.u.)                  :   -76.02676109578043
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858626
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	Scaled_SS Correlation Energy (a.u.):    -0.01690652121575
+	Scaled_OS Correlation Energy (a.u.):    -0.18115507030352
+	SCS-MP2 Total Energy (a.u.)        :   -76.22482268729971
+	SOS-MP2 Total Energy (a.u.)        :   -76.22301242194257
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11602752779960
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24535295259447
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.23810867780119
+	MP2 Correlation Energy (a.u.)      :    -0.20168212223352
+	MP2 Total Energy (a.u.)            :   -76.22844321801395
+	============================================================================== 
+
+	Using A=      0.3 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.2085613678    -76.2353224635     -6.88e-03     6.23e-07 
+   2     -0.2086385344    -76.2353996302     -7.72e-05     1.75e-07 
+   3     -0.2086497784    -76.2354108742     -1.12e-05     1.64e-08 
+   4     -0.2086602084    -76.2354213042     -1.04e-05     3.17e-09 
+   5     -0.2086607437    -76.2354218395     -5.35e-07     4.02e-10 
+   6     -0.2086607270    -76.2354218228      1.67e-08     5.32e-11 
+   7     -0.2086607345    -76.2354218303     -7.48e-09     9.31e-12 
+   8     -0.2086607350    -76.2354218308     -4.92e-10     1.10e-12 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578043
+	REF Energy (a.u.)                  :   -76.02676109578043
+	Alpha-Alpha Contribution (a.u.)    :    -0.02370139733232
+	Alpha-Beta Contribution (a.u.)     :    -0.16125794033886
+	Beta-Beta Contribution (a.u.)      :    -0.02370139733232
+	REMP Correlation Energy (a.u.)     :    -0.20866073500349
+	REMP Total Energy (a.u.)           :   -76.23542183078392
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 08:34:47 2021
+Module time:
+	user time   =       0.33 seconds =       0.01 minutes
+	system time =       0.27 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       5.82 seconds =       0.10 minutes
+	system time =       2.48 seconds =       0.04 minutes
+	total time  =          4 seconds =       0.07 minutes
+    REMP(0.30) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:47 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              RHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 0, multiplicity = 1:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 0
+  Multiplicity = 1
+  Electrons    = 10
+  Nalpha       = 5
+  Nbeta        = 5
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @RHF iter SAD:   -75.51052780814445   -7.55105e+01   0.00000e+00 
+   @RHF iter   1:   -75.95400376455578   -4.43476e-01   1.74090e-02 DIIS
+   @RHF iter   2:   -76.00728359240685   -5.32798e-02   9.94850e-03 DIIS
+   @RHF iter   3:   -76.02635567256031   -1.90721e-02   9.07658e-04 DIIS
+   @RHF iter   4:   -76.02674088207850   -3.85210e-04   2.08281e-04 DIIS
+   @RHF iter   5:   -76.02676015080984   -1.92687e-05   3.82846e-05 DIIS
+   @RHF iter   6:   -76.02676106936278   -9.18553e-07   6.09487e-06 DIIS
+   @RHF iter   7:   -76.02676109522359   -2.58608e-08   8.54125e-07 DIIS
+   @RHF iter   8:   -76.02676109574710   -5.23514e-10   1.98019e-07 DIIS
+   @RHF iter   9:   -76.02676109577956   -3.24576e-11   3.36831e-08 DIIS
+   @RHF iter  10:   -76.02676109578039   -8.24230e-13   2.77370e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Doubly Occupied:                                                      
+
+       1A    -20.550579     2A     -1.336336     3A     -0.698827  
+       4A     -0.566506     5A     -0.493105  
+
+    Virtual:                                                              
+
+       6A      0.185436     7A      0.256147     8A      0.788656  
+       9A      0.853784    10A      1.163587    11A      1.200369  
+      12A      1.253383    13A      1.444392    14A      1.476182  
+      15A      1.674338    16A      1.867382    17A      1.934293  
+      18A      2.451040    19A      2.488585    20A      3.285193  
+      21A      3.338052    22A      3.509722    23A      3.864815  
+      24A      4.146867  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     5 ]
+
+  @RHF Final Energy:   -76.02676109578039
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -123.1375894771224750
+    Two-Electron Energy =                  37.9234419237522644
+    Total Energy =                        -76.0267610957804010
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:    -0.1670
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:    -0.0000      Z:     0.8095     Total:     0.8095
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:    -0.0000      Z:     2.0576     Total:     2.0576
+
+
+*** tstop() called on south at Tue Nov 30 08:34:47 2021
+Module time:
+	user time   =       2.06 seconds =       0.03 minutes
+	system time =       0.68 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       7.92 seconds =       0.13 minutes
+	system time =       3.16 seconds =       0.05 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 08:34:47 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC    OCC   VIR  FV 
+	==============================
+	   A     1     4    19    0
+	==============================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578039
+	REF Energy (a.u.)                  :   -76.02676109578039
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858626
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	Scaled_SS Correlation Energy (a.u.):    -0.01690652121575
+	Scaled_OS Correlation Energy (a.u.):    -0.18115507030352
+	SCS-MP2 Total Energy (a.u.)        :   -76.22482268729966
+	SOS-MP2 Total Energy (a.u.)        :   -76.22301242194253
+	SCSN-MP2 Total Energy (a.u.)       :   -76.11602752779956
+	SCS-MP2-VDW Total Energy (a.u.)    :   -76.24535295259443
+	SOS-PI-MP2 Total Energy (a.u.)     :   -76.23810867780115
+	MP2 Correlation Energy (a.u.)      :    -0.20168212223352
+	MP2 Total Energy (a.u.)            :   -76.22844321801391
+	============================================================================== 
+
+	Using A=        1 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1983653529    -76.2251264487      3.32e-03     4.14e-06 
+   2     -0.2016821222    -76.2284432180     -3.32e-03     0.00e+00 
+   3     -0.2016821222    -76.2284432180      0.00e+00     5.45e-21 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -76.02676109578039
+	REF Energy (a.u.)                  :   -76.02676109578039
+	Alpha-Alpha Contribution (a.u.)    :    -0.02535978182363
+	Alpha-Beta Contribution (a.u.)     :    -0.15096255858626
+	Beta-Beta Contribution (a.u.)      :    -0.02535978182363
+	REMP Correlation Energy (a.u.)     :    -0.20168212223352
+	REMP Total Energy (a.u.)           :   -76.22844321801391
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 08:34:48 2021
+Module time:
+	user time   =       0.22 seconds =       0.00 minutes
+	system time =       0.15 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.15 seconds =       0.14 minutes
+	system time =       3.31 seconds =       0.06 minutes
+	total time  =          5 seconds =       0.08 minutes
+    REMP(1.00) Total Energy...............................................................PASSED
+
+    Psi4 stopped on: Tuesday, 30 November 2021 08:34AM
+    Psi4 wall time for execution: 0:00:04.22
+
+*** Psi4 exiting successfully. Buy a developer a beer!

--- a/tests/remp-energy2/CMakeLists.txt
+++ b/tests/remp-energy2/CMakeLists.txt
@@ -1,0 +1,3 @@
+include(TestingMacros)
+
+add_regression_test(remp-energy2 "psi;occ")

--- a/tests/remp-energy2/input.dat
+++ b/tests/remp-energy2/input.dat
@@ -1,0 +1,61 @@
+#! integral conventional unrestricted REMP/cc-pVDZ energies for the H2O+ molecule.
+#! results were independently verified against the initial wavels implementation
+
+
+test_dict = { "0.00": -75.80164576260127,  #TEST
+              "0.10": -75.79910145590183,  #TEST
+              "0.20": -75.79678966353273,  #TEST
+              "0.30": -75.79466003892817,  #TEST
+              "1.00": -75.78294942486372 } #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core true
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(1.00) Total Energy") #TEST
+

--- a/tests/remp-energy2/output.ref
+++ b/tests/remp-energy2/output.ref
@@ -1,0 +1,2228 @@
+
+    -----------------------------------------------------------------------
+          Psi4: An Open-Source Ab Initio Electronic Structure Package
+                               Psi4 undefined 
+
+                         Git: Rev {changes_for_global_merge} 9766b6f 
+
+
+    D. G. A. Smith, L. A. Burns, A. C. Simmonett, R. M. Parrish,
+    M. C. Schieber, R. Galvelis, P. Kraus, H. Kruse, R. Di Remigio,
+    A. Alenaizan, A. M. James, S. Lehtola, J. P. Misiewicz, M. Scheurer,
+    R. A. Shaw, J. B. Schriber, Y. Xie, Z. L. Glick, D. A. Sirianni,
+    J. S. O'Brien, J. M. Waldrop, A. Kumar, E. G. Hohenstein,
+    B. P. Pritchard, B. R. Brooks, H. F. Schaefer III, A. Yu. Sokolov,
+    K. Patkowski, A. E. DePrince III, U. Bozkaya, R. A. King,
+    F. A. Evangelista, J. M. Turney, T. D. Crawford, C. D. Sherrill,
+    J. Chem. Phys. 152(18) 184108 (2020). https://doi.org/10.1063/5.0006002
+
+                            Additional Code Authors
+    E. T. Seidl, C. L. Janssen, E. F. Valeev, M. L. Leininger,
+    J. F. Gonthier, R. M. Richard, H. R. McAlexander, M. Saitow, X. Wang,
+    P. Verma, and M. H. Lechner
+
+             Previous Authors, Complete List of Code Contributors,
+                       and Citations for Specific Modules
+    https://github.com/psi4/psi4/blob/master/codemeta.json
+    https://github.com/psi4/psi4/graphs/contributors
+    http://psicode.org/psi4manual/master/introduction.html#citing-psifour
+
+    -----------------------------------------------------------------------
+
+
+    Psi4 started on: Tuesday, 30 November 2021 01:58PM
+
+    Process ID: 25215
+    Host:       south
+    PSIDATADIR: /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4
+    Memory:     500.0 MiB
+    Threads:    4
+    
+  ==> Input File <==
+
+--------------------------------------------------------------------------
+#! integral conventional REMP/cc-pVDZ energies for the H2O+ molecule.
+
+test_dict = { "0.00": -75.80164576260127,  #TEST
+              "0.10": -75.79910145590183,  #TEST
+              "0.20": -75.79678966353273,  #TEST
+              "0.30": -75.79466003892817,  #TEST
+              "1.00": -75.78294942486372 } #TEST
+
+molecule h2o {
+1 2
+o
+h 1 0.958
+h 1 0.958 2 104.4776 
+symmetry c1
+}
+
+set {
+  reference uhf
+  basis cc-pvdz
+  guess sad
+  scf_type out_of_core
+  freeze_core true
+  cc_type conv
+  e_convergence 1.0E-9
+  r_convergence 1.0E-8
+  qc_module occ
+}
+
+Avals=[0.00, 0.10, 0.20, 0.30, 1.00]
+
+
+#for A in Avals:
+#     psi4.print_out("running step %5.2f" % A)
+#     set remp_A=$A
+#     e_remp=energy('remp')
+#     compare_values(test_dict[remp_A], get_variable("REMP TOTAL ENERGY"), 6, "REMP Total Energy") #TEST
+
+
+
+set remp_A=0.00
+e_remp=energy('remp')
+compare_values(test_dict["0.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.00) Total Energy") #TEST
+
+set remp_A=0.10
+e_remp=energy('remp')
+compare_values(test_dict["0.10"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.10) Total Energy") #TEST
+
+set remp_A=0.20
+e_remp=energy('remp')
+compare_values(test_dict["0.20"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.20) Total Energy") #TEST
+
+set remp_A=0.30
+e_remp=energy('remp')
+compare_values(test_dict["0.30"], variable("REMP TOTAL ENERGY"), 6, "REMP(0.30) Total Energy") #TEST
+
+set remp_A=1.00
+e_remp=energy('remp')
+compare_values(test_dict["1.00"], variable("REMP TOTAL ENERGY"), 6, "REMP(1.00) Total Energy") #TEST
+
+--------------------------------------------------------------------------
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:02 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814436   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757604   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039660   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127693   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068533   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929177   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485056   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373724   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376488   -5.00276e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462479   -8.59913e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466289   -3.80993e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466400   -1.10845e-12   7.40709e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087274240E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872742E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466400
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596541309884060
+    Two-Electron Energy =                  33.2403702187346042
+    Total Energy =                        -75.6318974546639993
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Tue Nov 30 13:58:03 2021
+Module time:
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       1.32 seconds =       0.02 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:03 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     1     4     3    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466400
+	REF Energy (a.u.)                  :   -75.63189745466400
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	Scaled_SS Correlation Energy (a.u.):    -0.01171340473405
+	Scaled_OS Correlation Energy (a.u.):    -0.13909410719705
+	SCS-MP2 Total Energy (a.u.)        :   -75.78270496659509
+	SOS-MP2 Total Energy (a.u.)        :   -75.78258273746080
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69374423165976
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.79783460944194
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79417391306056
+	MP2 Correlation Energy (a.u.)      :    -0.15105197019968
+	MP2 Total Energy (a.u.)            :   -75.78294942486367
+	============================================================================== 
+
+	Using A=        0 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1510519702    -75.7829494249      0.00e+00     3.59e-05 
+   2     -0.1649625121    -75.7968599668     -1.39e-02     5.89e-06 
+   3     -0.1681596912    -75.8000571459     -3.20e-03     2.14e-06 
+   4     -0.1694362613    -75.8013337160     -1.28e-03     7.67e-07 
+   5     -0.1696758565    -75.8015733111     -2.40e-04     3.46e-07 
+   6     -0.1697330249    -75.8016304796     -5.72e-05     1.16e-07 
+   7     -0.1697444917    -75.8016419463     -1.15e-05     3.44e-08 
+   8     -0.1697481400    -75.8016455946     -3.65e-06     1.28e-08 
+   9     -0.1697483995    -75.8016458542     -2.60e-07     5.27e-09 
+  10     -0.1697481646    -75.8016456193      2.35e-07     1.50e-09 
+  11     -0.1697481853    -75.8016456399     -2.07e-08     4.92e-10 
+  12     -0.1697482590    -75.8016457137     -7.37e-08     1.49e-10 
+  13     -0.1697482900    -75.8016457447     -3.10e-08     6.29e-11 
+  14     -0.1697483010    -75.8016457557     -1.10e-08     2.76e-11 
+  15     -0.1697483051    -75.8016457598     -4.10e-09     1.19e-11 
+  16     -0.1697483073    -75.8016457619     -2.17e-09     3.83e-12 
+  17     -0.1697483078    -75.8016457625     -5.52e-10     1.68e-12 
+  18     -0.1697483079    -75.8016457626     -1.01e-10     7.00e-13 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466400
+	REF Energy (a.u.)                  :   -75.63189745466400
+	Alpha-Alpha Contribution (a.u.)    :    -0.02341378457727
+	Alpha-Beta Contribution (a.u.)     :    -0.13589689886670
+	Beta-Beta Contribution (a.u.)      :    -0.01043762449332
+	REMP Correlation Energy (a.u.)     :    -0.16974830793728
+	REMP Total Energy (a.u.)           :   -75.80164576260128
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 13:58:03 2021
+Module time:
+	user time   =       0.93 seconds =       0.02 minutes
+	system time =       0.88 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       1.34 seconds =       0.02 minutes
+	total time  =          1 seconds =       0.02 minutes
+    REMP(0.00) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:03 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814436   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757604   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039663   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127697   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929184   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485060   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373730   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376498   -5.00277e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462492   -8.59941e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466293   -3.80140e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466403   -1.09424e-12   7.40709e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087274240E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872742E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466403
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596541309884770
+    Two-Electron Energy =                  33.2403702187346326
+    Total Energy =                        -75.6318974546640277
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:    -0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:    -0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Tue Nov 30 13:58:04 2021
+Module time:
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       3.45 seconds =       0.06 minutes
+	system time =       1.71 seconds =       0.03 minutes
+	total time  =          2 seconds =       0.03 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:04 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.1             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     1     4     3    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466403
+	REF Energy (a.u.)                  :   -75.63189745466403
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	Scaled_SS Correlation Energy (a.u.):    -0.01171340473405
+	Scaled_OS Correlation Energy (a.u.):    -0.13909410719705
+	SCS-MP2 Total Energy (a.u.)        :   -75.78270496659512
+	SOS-MP2 Total Energy (a.u.)        :   -75.78258273746083
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69374423165979
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.79783460944196
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79417391306058
+	MP2 Correlation Energy (a.u.)      :    -0.15105197019968
+	MP2 Total Energy (a.u.)            :   -75.78294942486370
+	============================================================================== 
+
+	Using A=      0.1 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1678786742    -75.7997761288     -1.68e-02     1.04e-06 
+   2     -0.1674479525    -75.7993454072      4.31e-04     4.69e-07 
+   3     -0.1672315959    -75.7991290505      2.16e-04     1.58e-07 
+   4     -0.1672074082    -75.7991048629      2.42e-05     4.82e-08 
+   5     -0.1672042183    -75.7991016730      3.19e-06     9.22e-09 
+   6     -0.1672040323    -75.7991014870      1.86e-07     3.00e-09 
+   7     -0.1672039779    -75.7991014325      5.44e-08     1.05e-09 
+   8     -0.1672039975    -75.7991014521     -1.96e-08     3.02e-10 
+   9     -0.1672040089    -75.7991014635     -1.14e-08     7.10e-11 
+  10     -0.1672040063    -75.7991014610      2.54e-09     1.95e-11 
+  11     -0.1672040032    -75.7991014578      3.14e-09     6.89e-12 
+  12     -0.1672040019    -75.7991014565      1.30e-09     3.28e-12 
+  13     -0.1672040013    -75.7991014560      5.34e-10     9.66e-13 
+  14     -0.1672040012    -75.7991014559      9.99e-11     2.61e-13 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466403
+	REF Energy (a.u.)                  :   -75.63189745466403
+	Alpha-Alpha Contribution (a.u.)    :    -0.02356979156837
+	Alpha-Beta Contribution (a.u.)     :    -0.13306195324279
+	Beta-Beta Contribution (a.u.)      :    -0.01057225642664
+	REMP Correlation Energy (a.u.)     :    -0.16720400123781
+	REMP Total Energy (a.u.)           :   -75.79910145590183
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 13:58:04 2021
+Module time:
+	user time   =       0.78 seconds =       0.01 minutes
+	system time =       0.68 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       4.23 seconds =       0.07 minutes
+	system time =       2.39 seconds =       0.04 minutes
+	total time  =          2 seconds =       0.03 minutes
+    REMP(0.10) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:04 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814442   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757604   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039660   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127698   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929184   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485063   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373726   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00277e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462483   -8.59885e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466293   -3.80993e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466404   -1.10845e-12   7.40709e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087274240E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872742E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466404
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596541309883492
+    Two-Electron Energy =                  33.2403702187344976
+    Total Energy =                        -75.6318974546640419
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:    -0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:    -0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Tue Nov 30 13:58:05 2021
+Module time:
+	user time   =       2.25 seconds =       0.04 minutes
+	system time =       0.56 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       6.51 seconds =       0.11 minutes
+	system time =       2.96 seconds =       0.05 minutes
+	total time  =          3 seconds =       0.05 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:05 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.2             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     1     4     3    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466404
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	Scaled_SS Correlation Energy (a.u.):    -0.01171340473405
+	Scaled_OS Correlation Energy (a.u.):    -0.13909410719705
+	SCS-MP2 Total Energy (a.u.)        :   -75.78270496659513
+	SOS-MP2 Total Energy (a.u.)        :   -75.78258273746084
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69374423165981
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.79783460944198
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79417391306060
+	MP2 Correlation Energy (a.u.)      :    -0.15105197019968
+	MP2 Total Energy (a.u.)            :   -75.78294942486372
+	============================================================================== 
+
+	Using A=      0.2 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1654093311    -75.7973067858     -1.44e-02     9.41e-07 
+   2     -0.1650505614    -75.7969480161      3.59e-04     3.58e-07 
+   3     -0.1649054089    -75.7968028636      1.45e-04     9.90e-08 
+   4     -0.1648934416    -75.7967908962      1.20e-05     2.60e-08 
+   5     -0.1648922878    -75.7967897425      1.15e-06     4.10e-09 
+   6     -0.1648922220    -75.7967896766      6.58e-08     1.11e-09 
+   7     -0.1648922031    -75.7967896578      1.89e-08     3.30e-10 
+   8     -0.1648922079    -75.7967896626     -4.79e-09     8.18e-11 
+   9     -0.1648922103    -75.7967896649     -2.38e-09     1.62e-11 
+  10     -0.1648922096    -75.7967896643      6.39e-10     3.83e-12 
+  11     -0.1648922091    -75.7967896637      5.66e-10     1.16e-12 
+  12     -0.1648922089    -75.7967896635      1.91e-10     4.72e-13 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466404
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02369492881558
+	Alpha-Beta Contribution (a.u.)     :    -0.13051319175142
+	Beta-Beta Contribution (a.u.)      :    -0.01068408830166
+	REMP Correlation Energy (a.u.)     :    -0.16489220886866
+	REMP Total Energy (a.u.)           :   -75.79678966353271
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 13:58:06 2021
+Module time:
+	user time   =       0.67 seconds =       0.01 minutes
+	system time =       0.60 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       7.19 seconds =       0.12 minutes
+	system time =       3.56 seconds =       0.06 minutes
+	total time  =          4 seconds =       0.07 minutes
+    REMP(0.20) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:06 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814439   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757608   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039663   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127707   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068539   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929184   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485058   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373730   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376498   -5.00277e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462491   -8.59927e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466291   -3.79998e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466404   -1.13687e-12   7.40709e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087274240E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872742E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466404
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596541309883349
+    Two-Electron Energy =                  33.2403702187344976
+    Total Energy =                        -75.6318974546640277
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Tue Nov 30 13:58:06 2021
+Module time:
+	user time   =       1.18 seconds =       0.02 minutes
+	system time =       0.35 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =       8.40 seconds =       0.14 minutes
+	system time =       3.91 seconds =       0.07 minutes
+	total time  =          4 seconds =       0.07 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:06 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 0.3             !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     1     4     3    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466404
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	Scaled_SS Correlation Energy (a.u.):    -0.01171340473405
+	Scaled_OS Correlation Energy (a.u.):    -0.13909410719705
+	SCS-MP2 Total Energy (a.u.)        :   -75.78270496659513
+	SOS-MP2 Total Energy (a.u.)        :   -75.78258273746084
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69374423165981
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.79783460944198
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79417391306059
+	MP2 Correlation Energy (a.u.)      :    -0.15105197019968
+	MP2 Total Energy (a.u.)            :   -75.78294942486372
+	============================================================================== 
+
+	Using A=      0.3 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1631621790    -75.7950596336     -1.21e-02     8.68e-07 
+   2     -0.1628655753    -75.7947630300      2.97e-04     2.78e-07 
+   3     -0.1627689517    -75.7946664063      9.66e-05     6.22e-08 
+   4     -0.1627630204    -75.7946604751      5.93e-06     1.38e-08 
+   5     -0.1627626121    -75.7946600668      4.08e-07     1.79e-09 
+   6     -0.1627625889    -75.7946600435      2.32e-08     4.00e-10 
+   7     -0.1627625827    -75.7946600373      6.20e-09     9.99e-11 
+   8     -0.1627625838    -75.7946600385     -1.12e-09     2.11e-11 
+   9     -0.1627625843    -75.7946600389     -4.66e-10     3.46e-12 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466404
+	REF Energy (a.u.)                  :   -75.63189745466404
+	Alpha-Alpha Contribution (a.u.)    :    -0.02379427247760
+	Alpha-Beta Contribution (a.u.)     :    -0.12819125608449
+	Beta-Beta Contribution (a.u.)      :    -0.01077705570205
+	REMP Correlation Energy (a.u.)     :    -0.16276258426414
+	REMP Total Energy (a.u.)           :   -75.79466003892819
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 13:58:07 2021
+Module time:
+	user time   =       0.48 seconds =       0.01 minutes
+	system time =       0.45 seconds =       0.01 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =       8.89 seconds =       0.15 minutes
+	system time =       4.36 seconds =       0.07 minutes
+	total time  =          5 seconds =       0.08 minutes
+    REMP(0.30) Total Energy...............................................................PASSED
+
+Scratch directory: /scr/behnle/
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:07 2021
+
+   => Loading Basis Set <=
+
+    Name: CC-PVDZ
+    Role: ORBITAL
+    Keyword: BASIS
+    atoms 1   entry O          line   198 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+    atoms 2-3 entry H          line    22 file /mnt/home/behnle/prog/psi4/psi4/objdir_python39/stage/share/psi4/basis/cc-pvdz.gbs 
+
+
+         ---------------------------------------------------------
+                                   SCF
+               by Justin Turney, Rob Parrish, Andy Simmonett
+                          and Daniel G. A. Smith
+                              UHF Reference
+                        4 Threads,    500 MiB Core
+         ---------------------------------------------------------
+
+  ==> Geometry <==
+
+    Molecular point group: c1
+    Full point group: C2v
+
+    Geometry (in Angstrom), charge = 1, multiplicity = 2:
+
+       Center              X                  Y                   Z               Mass       
+    ------------   -----------------  -----------------  -----------------  -----------------
+         O            0.000000000000     0.000000000000    -0.065655108083    15.994914619570
+         H            0.000000000000    -0.757365949175     0.520997104927     1.007825032230
+         H            0.000000000000     0.757365949175     0.520997104927     1.007825032230
+
+  Running in c1 symmetry.
+
+  Rotational constants: A =     27.36310  B =     14.58041  C =      9.51197 [cm^-1]
+  Rotational constants: A = 820325.17390  B = 437109.76779  C = 285161.58919 [MHz]
+  Nuclear repulsion =    9.187386457589815
+
+  Charge       = 1
+  Multiplicity = 2
+  Electrons    = 9
+  Nalpha       = 5
+  Nbeta        = 4
+
+  ==> Algorithm <==
+
+  SCF Algorithm Type is OUT_OF_CORE.
+  DIIS enabled.
+  MOM disabled.
+  Fractional occupation disabled.
+  Guess Type is SAD.
+  Energy threshold   = 1.00e-09
+  Density threshold  = 1.00e-08
+  Integral threshold = 1.00e-12
+
+  ==> Primary Basis <==
+
+  Basis Set: CC-PVDZ
+    Blend: CC-PVDZ
+    Number of shells: 12
+    Number of basis functions: 24
+    Number of Cartesian functions: 25
+    Spherical Harmonics?: true
+    Max angular momentum: 2
+
+  ==> Integral Setup <==
+
+  ==> DiskJK: Disk-Based J/K Matrices <==
+
+    J tasked:                  Yes
+    K tasked:                  Yes
+    wK tasked:                  No
+    Memory [MiB]:              375
+    Schwarz Cutoff:          1E-12
+
+  Minimum eigenvalue in the overlap matrix is 3.4230868396E-02.
+  Reciprocal condition number of the overlap matrix is 9.2312643042E-03.
+    Using symmetric orthogonalization.
+
+  ==> Pre-Iterations <==
+
+  SCF Guess: Superposition of Atomic Densities via on-the-fly atomic UHF (no occupation information).
+
+   -------------------------
+    Irrep   Nso     Nmo    
+   -------------------------
+     A         24      24 
+   -------------------------
+    Total      24      24
+   -------------------------
+
+  ==> Iterations <==
+
+                        Total Energy        Delta E     RMS |[F,P]|
+
+   @UHF iter SAD:   -75.51052780814439   -7.55105e+01   0.00000e+00 
+   @UHF iter   1:   -75.59297510757605   -8.24473e-02   1.13724e-02 DIIS
+   @UHF iter   2:   -75.62902947039663   -3.60544e-02   3.07775e-03 DIIS
+   @UHF iter   3:   -75.63141603127698   -2.38656e-03   1.08976e-03 DIIS
+   @UHF iter   4:   -75.63180036068542   -3.84329e-04   3.53756e-04 DIIS
+   @UHF iter   5:   -75.63187465929180   -7.42986e-05   1.56819e-04 DIIS
+   @UHF iter   6:   -75.63189525485063   -2.05956e-05   4.78729e-05 DIIS
+   @UHF iter   7:   -75.63189740373730   -2.14889e-06   8.09722e-06 DIIS
+   @UHF iter   8:   -75.63189745376495   -5.00277e-08   1.25103e-06 DIIS
+   @UHF iter   9:   -75.63189745462491   -8.59956e-10   2.49843e-07 DIIS
+   @UHF iter  10:   -75.63189745466288   -3.79714e-11   4.17817e-08 DIIS
+   @UHF iter  11:   -75.63189745466406   -1.17950e-12   7.40709e-09 DIIS
+  Energy and wave function converged.
+
+
+  ==> Post-Iterations <==
+
+   @Spin Contamination Metric:   6.087274240E-03
+   @S^2 Expected:                7.500000000E-01
+   @S^2 Observed:                7.560872742E-01
+   @S   Expected:                5.000000000E-01
+   @S   Observed:                5.000000000E-01
+
+    Orbital Energies [Eh]
+    ---------------------
+
+    Alpha Occupied:                                                       
+
+       1A    -21.140116     2A     -1.913841     3A     -1.218289  
+       4A     -1.130152     5A     -1.097762  
+
+    Alpha Virtual:                                                        
+
+       6A     -0.141739     7A     -0.058355     8A      0.392700  
+       9A      0.447053    10A      0.672492    11A      0.714762  
+      12A      0.827147    13A      1.024661    14A      1.039614  
+      15A      1.238674    16A      1.385130    17A      1.531578  
+      18A      1.995638    19A      2.003995    20A      2.722514  
+      21A      2.773398    22A      3.000585    23A      3.326128  
+      24A      3.652695  
+
+    Beta Occupied:                                                        
+
+       1A    -21.095041     2A     -1.757773     3A     -1.180062  
+       4A     -1.045877  
+
+    Beta Virtual:                                                         
+
+       5A     -0.313565     6A     -0.127673     7A     -0.050162  
+       8A      0.391528     9A      0.463531    10A      0.736114  
+      11A      0.844549    12A      0.870042    13A      1.035530  
+      14A      1.070107    15A      1.268969    16A      1.437749  
+      17A      1.528504    18A      2.007227    19A      2.059735  
+      20A      2.826417    21A      2.877972    22A      3.032387  
+      23A      3.404869    24A      3.670432  
+
+    Final Occupation by Irrep:
+              A 
+    DOCC [     4 ]
+    SOCC [     1 ]
+
+  @UHF Final Energy:   -75.63189745466406
+
+   => Energetics <=
+
+    Nuclear Repulsion Energy =              9.1873864575898150
+    One-Electron Energy =                -118.0596541309884202
+    Two-Electron Energy =                  33.2403702187345687
+    Total Energy =                        -75.6318974546640419
+
+  UHF NO Occupations:
+  HONO-2 :    3  A 1.9991850
+  HONO-1 :    4  A 1.9980710
+  HONO-0 :    5  A 1.0000000
+  LUNO+0 :    6  A 0.0019290
+  LUNO+1 :    7  A 0.0008150
+  LUNO+2 :    8  A 0.0003016
+  LUNO+3 :    9  A 0.0000003
+
+
+Computation Completed
+
+
+Properties will be evaluated at   0.000000,   0.000000,   0.000000 [a0]
+
+Properties computed using the SCF density matrix
+
+  Nuclear Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9765
+
+  Electronic Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.0132
+
+  Dipole Moment: [e a0]
+     X:     0.0000      Y:     0.0000      Z:     0.9897     Total:     0.9897
+
+  Dipole Moment: [D]
+     X:     0.0000      Y:     0.0000      Z:     2.5156     Total:     2.5156
+
+
+*** tstop() called on south at Tue Nov 30 13:58:07 2021
+Module time:
+	user time   =       1.43 seconds =       0.02 minutes
+	system time =       0.54 seconds =       0.01 minutes
+	total time  =          0 seconds =       0.00 minutes
+Total time:
+	user time   =      10.34 seconds =       0.17 minutes
+	system time =       4.92 seconds =       0.08 minutes
+	total time  =          5 seconds =       0.08 minutes
+
+*** tstart() called on south
+*** at Tue Nov 30 13:58:07 2021
+
+
+
+  Module OCC Options:
+  ----------------------------------------------------------------------------
+  ACTIVE                        => (empty)          
+  BASIS_RELATIVISTIC            => (empty)          
+  BENCH                         => (empty)          
+  CACHELEVEL                    => (empty)          
+  CCL_ENERGY                    => (empty)          
+  CC_DIIS_MAX_VECS              => (empty)          
+  CC_DIIS_MIN_VECS              => (empty)          
+  CC_MAXITER                    => (empty)          
+  CC_TYPE                       => CONV            !
+  CEPA_OS_SCALE                 => (empty)          
+  CEPA_SOS_SCALE                => (empty)          
+  CEPA_SS_SCALE                 => (empty)          
+  CEPA_TYPE                     => (empty)          
+  CI_TYPE                       => (empty)          
+  CUBEPROP_BASIS_FUNCTIONS      => (empty)          
+  CUBEPROP_FILEPATH             => (empty)          
+  CUBEPROP_ISOCONTOUR_THRESHOLD => (empty)          
+  CUBEPROP_ORBITALS             => (empty)          
+  CUBEPROP_TASKS                => (empty)          
+  CUBIC_BASIS_TOLERANCE         => (empty)          
+  CUBIC_BLOCK_MAX_POINTS        => (empty)          
+  CUBIC_GRID_OVERAGE            => (empty)          
+  CUBIC_GRID_SPACING            => (empty)          
+  CUTOFF                        => (empty)          
+  DEBUG                         => (empty)          
+  DERTYPE                       => (empty)          
+  DF_BASIS_CC                   => (empty)          
+  DIE_IF_NOT_CONVERGED          => (empty)          
+  DIIS_MAX_VECS                 => (empty)          
+  DIIS_MIN_VECS                 => (empty)          
+  DKH_ORDER                     => (empty)          
+  DOCC                          => (empty)          
+  DO_DIIS                       => (empty)          
+  DO_LEVEL_SHIFT                => (empty)          
+  DO_SCS                        => (empty)          
+  DO_SOS                        => (empty)          
+  E3_SCALE                      => (empty)          
+  EA_POLES                      => (empty)          
+  EKT_EA                        => (empty)          
+  EKT_IP                        => (empty)          
+  EP_EA_POLES                   => (empty)          
+  EP_IP_POLES                   => (empty)          
+  EP_MAXITER                    => (empty)          
+  EXTERNAL_POTENTIAL_SYMMETRY   => (empty)          
+  E_CONVERGENCE                 => 1e-09           !
+  FREEZE_CORE                   => TRUE            !
+  FROZEN_DOCC                   => (empty)          
+  FROZEN_UOCC                   => (empty)          
+  INTEGRAL_PACKAGE              => (empty)          
+  IP_POLES                      => (empty)          
+  LEVEL_SHIFT                   => (empty)          
+  LINEQ_SOLVER                  => (empty)          
+  LITERAL_CFOUR                 => (empty)          
+  MAT_NUM_COLUMN_PRINT          => (empty)          
+  MAX_MOGRAD_CONVERGENCE        => (empty)          
+  MAX_RADIAL_MOMENT             => (empty)          
+  MBIS_D_CONVERGENCE            => (empty)          
+  MBIS_MAXITER                  => (empty)          
+  MBIS_PRUNING_SCHEME           => (empty)          
+  MBIS_RADIAL_POINTS            => (empty)          
+  MBIS_SPHERICAL_POINTS         => (empty)          
+  MOGRAD_DAMPING                => (empty)          
+  MOLDEN_WITH_VIRTUAL           => (empty)          
+  MO_DIIS_NUM_VECS              => (empty)          
+  MO_MAXITER                    => (empty)          
+  MO_READ                       => (empty)          
+  MO_STEP_MAX                   => (empty)          
+  MO_WRITE                      => (empty)          
+  MP2_OS_SCALE                  => (empty)          
+  MP2_SOS_SCALE                 => (empty)          
+  MP2_SOS_SCALE2                => (empty)          
+  MP2_SS_SCALE                  => (empty)          
+  MP2_TYPE                      => (empty)          
+  MP_TYPE                       => (empty)          
+  NAT_ORBS                      => (empty)          
+  NUM_FROZEN_DOCC               => (empty)          
+  NUM_FROZEN_UOCC               => (empty)          
+  NUM_GPUS                      => (empty)          
+  OCC_ORBS_PRINT                => (empty)          
+  OEPROP                        => (empty)          
+  OPT_METHOD                    => (empty)          
+  ORB_OPT                       => FALSE           !
+  ORB_RESP_SOLVER               => (empty)          
+  ORTH_TYPE                     => (empty)          
+  OS_SCALE                      => (empty)          
+  PARENT_SYMMETRY               => (empty)          
+  PCG_BETA_TYPE                 => (empty)          
+  PCG_CONVERGENCE               => (empty)          
+  PCG_MAXITER                   => (empty)          
+  PCM                           => (empty)          
+  PE                            => (empty)          
+  PRINT                         => (empty)          
+  PRINT_NOONS                   => (empty)          
+  PROPERTIES                    => (empty)          
+  PROPERTIES_ORIGIN             => (empty)          
+  PUREAM                        => (empty)          
+  QC_MODULE                     => OCC             !
+  RAS1                          => (empty)          
+  RAS2                          => (empty)          
+  RAS3                          => (empty)          
+  RAS4                          => (empty)          
+  RELATIVISTIC                  => (empty)          
+  RELAXED                       => (empty)          
+  REMP_A                        => 1               !
+  RESTRICTED_DOCC               => (empty)          
+  RESTRICTED_UOCC               => (empty)          
+  RMS_MOGRAD_CONVERGENCE        => (empty)          
+  R_CONVERGENCE                 => 1e-08           !
+  SCF_TYPE                      => OUT_OF_CORE     !
+  SCS_TYPE                      => (empty)          
+  SOCC                          => (empty)          
+  SOS_TYPE                      => (empty)          
+  SPIN_SCALE_TYPE               => NONE            !
+  SS_SCALE                      => (empty)          
+  SYMMETRIZE                    => (empty)          
+  TPDM_ABCD_TYPE                => (empty)          
+  WFN                           => (empty)          
+  WFN_TYPE                      => REMP            !
+  WRITER_FILE_LABEL             => (empty)          
+
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+                             REMP2  
+                    Program Written by Ugur Bozkaya,
+              Additional Contributions by J. P. Misiewicz
+
+ ============================================================================== 
+ ============================================================================== 
+ ============================================================================== 
+
+	MO spaces per irreps... 
+
+	IRREP   FC   AOCC  BOCC  AVIR    BVIR  FV 
+	==========================================
+	   A     1     4     3    19     20     0
+	==========================================
+
+	Computing MP2 energy using SCF MOs (Canonical MP2)... 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466406
+	REF Energy (a.u.)                  :   -75.63189745466406
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	Scaled_SS Correlation Energy (a.u.):    -0.01171340473405
+	Scaled_OS Correlation Energy (a.u.):    -0.13909410719705
+	SCS-MP2 Total Energy (a.u.)        :   -75.78270496659515
+	SOS-MP2 Total Energy (a.u.)        :   -75.78258273746086
+	SCSN-MP2 Total Energy (a.u.)       :   -75.69374423165982
+	SCS-MP2-VDW Total Energy (a.u.)    :   -75.79783460944199
+	SOS-PI-MP2 Total Energy (a.u.)     :   -75.79417391306062
+	MP2 Correlation Energy (a.u.)      :    -0.15105197019968
+	MP2 Total Energy (a.u.)            :   -75.78294942486373
+	============================================================================== 
+
+	Using A=        1 as REMP mixing parameter
+
+  
+ ============================================================================== 
+ ================ Performing REMP iterations ... ============================== 
+ ============================================================================== 
+
+  Iter    E_corr           E_total            DE           T2 RMS        
+  ----   -------------    ---------------    ----------   ----------    
+   1     -0.1510519702    -75.7829494249      0.00e+00     5.68e-06 
+   2     -0.1510519702    -75.7829494249      0.00e+00     0.00e+00 
+
+ ============================================================================== 
+ ======================== REMP ITERATIONS ARE CONVERGED ======================= 
+ ============================================================================== 
+
+	============================================================================== 
+	================ REMP2 FINAL RESULTS ================================ 
+	============================================================================== 
+	Nuclear Repulsion Energy (a.u.)    :     9.18738645758981
+	SCF Energy (a.u.)                  :   -75.63189745466406
+	REF Energy (a.u.)                  :   -75.63189745466406
+	Alpha-Alpha Contribution (a.u.)    :    -0.02403737176609
+	Alpha-Beta Contribution (a.u.)     :    -0.11591175599754
+	Beta-Beta Contribution (a.u.)      :    -0.01110284243605
+	REMP Correlation Energy (a.u.)     :    -0.15105197019967
+	REMP Total Energy (a.u.)           :   -75.78294942486373
+	============================================================================== 
+
+
+*** tstop() called on south at Tue Nov 30 13:58:08 2021
+Module time:
+	user time   =       0.18 seconds =       0.00 minutes
+	system time =       0.19 seconds =       0.00 minutes
+	total time  =          1 seconds =       0.02 minutes
+Total time:
+	user time   =      10.53 seconds =       0.18 minutes
+	system time =       5.12 seconds =       0.09 minutes
+	total time  =          6 seconds =       0.10 minutes
+    REMP(1.00) Total Energy...............................................................PASSED
+
+    Psi4 stopped on: Tuesday, 30 November 2021 01:58PM
+    Psi4 wall time for execution: 0:00:05.83
+
+*** Psi4 exiting successfully. Buy a developer a beer!


### PR DESCRIPTION
Added test cases for REMP and OREMP:
- closed shell canonical REMP energy
- unrestricted open shell canonical REMP energy
- closed shell DF-REMP energy
- unrestricted open shell DF-REMP energy
- closed shell CD-REMP energy
- unrestricted open shell CD-REMP energy
- closed shell canonical OREMP energy and gradient
- open shell canonical OREMP energy and gradient
- closed shell DF-OREMP energy and gradient
- open shell DF-OREMP energy and gradient
- closed shell CD-OREMP energy
- open shell CD-OREMP energ

## Checklist
- [x] Tests added for REMP and OREMP

## Status
- [x] Ready for review

